### PR TITLE
shelley/ui: fix manifest.json failing to load behind auth proxy

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -10,7 +10,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Shelley" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>Shelley Agent</title>
     <link rel="stylesheet" href="/styles.css" />


### PR DESCRIPTION
## What

Add `crossorigin="use-credentials"` attribute to the manifest link tag.

## Why

When Shelley runs behind an authentication proxy (e.g., exe.dev), the browser fetches `manifest.json` without cookies by default. This causes the proxy to redirect to the auth endpoint, and the manifest fails to load:

`GET https://exe.dev/auth?redirect=https%3A%2F%2Fexample-vm-name.exe.xyz%3A9999%2Fmanifest.json&return_host=example-vm-name.exe.xyz%3A9999 net::ERR_FAILED 401 (Unauthorized)`

## How

The `crossorigin="use-credentials"` attribute instructs the browser to include cookies when fetching the manifest, allowing the request to pass through the auth proxy without redirection.