### PR TITLE
Load skills from XDG_CONFIG_HOME/agents/skills

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -1,0 +1,39 @@
+// Package paths provides utilities for resolving configuration paths.
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ConfigHome returns the XDG config directory.
+// It uses XDG_CONFIG_HOME if set, otherwise falls back to ~/.config.
+func ConfigHome() string {
+	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
+		return configHome
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config")
+	}
+	return ""
+}
+
+// ShelleyConfigDir returns the shelley-specific config directory.
+// This is $XDG_CONFIG_HOME/shelley or ~/.config/shelley.
+func ShelleyConfigDir() string {
+	if configHome := ConfigHome(); configHome != "" {
+		return filepath.Join(configHome, "shelley")
+	}
+	return ""
+}
+
+// ExpandPath expands ~ to the user's home directory.
+func ExpandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -1,0 +1,91 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+
+	// Test default (no XDG_CONFIG_HOME set)
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		got := ConfigHome()
+		want := filepath.Join(home, ".config")
+		if got != want {
+			t.Errorf("ConfigHome() = %q, want %q", got, want)
+		}
+	})
+
+	// Test with XDG_CONFIG_HOME set
+	t.Run("custom", func(t *testing.T) {
+		customConfig := "/custom/config"
+		t.Setenv("XDG_CONFIG_HOME", customConfig)
+		got := ConfigHome()
+		if got != customConfig {
+			t.Errorf("ConfigHome() with XDG_CONFIG_HOME = %q, want %q", got, customConfig)
+		}
+	})
+}
+
+func TestShelleyConfigDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+
+	// Test default
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		got := ShelleyConfigDir()
+		want := filepath.Join(home, ".config", "shelley")
+		if got != want {
+			t.Errorf("ShelleyConfigDir() = %q, want %q", got, want)
+		}
+	})
+
+	// Test with XDG_CONFIG_HOME set
+	t.Run("custom", func(t *testing.T) {
+		customConfig := "/custom/config"
+		t.Setenv("XDG_CONFIG_HOME", customConfig)
+		got := ShelleyConfigDir()
+		want := filepath.Join(customConfig, "shelley")
+		if got != want {
+			t.Errorf("ShelleyConfigDir() with XDG_CONFIG_HOME = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~/foo", filepath.Join(home, "foo")},
+		{"~/foo/bar", filepath.Join(home, "foo", "bar")},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"~notahome", "~notahome"},
+		{"", ""},
+		{"~", "~"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ExpandPath(tt.input)
+			if got != tt.want {
+				t.Errorf("ExpandPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/system_prompt.go
+++ b/server/system_prompt.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"shelley.exe.dev/paths"
 	"shelley.exe.dev/skills"
 )
 
@@ -156,16 +157,17 @@ func collectCodebaseInfo(wd string, gitInfo *GitInfo) (*CodebaseInfo, error) {
 	// Track seen files to avoid duplicates on case-insensitive file systems
 	seenFiles := make(map[string]bool)
 
-	// Check for user-level agent instructions in ~/.config/shelley/AGENTS.md and ~/.shelley/AGENTS.md
-	if home, err := os.UserHomeDir(); err == nil {
-		// Prefer ~/.config/shelley/AGENTS.md (XDG convention)
-		configAgentsFile := filepath.Join(home, ".config", "shelley", "AGENTS.md")
+	// Check for user-level agent instructions in $XDG_CONFIG_HOME/shelley/AGENTS.md and ~/.shelley/AGENTS.md
+	if configDir := paths.ShelleyConfigDir(); configDir != "" {
+		configAgentsFile := filepath.Join(configDir, "AGENTS.md")
 		if content, err := os.ReadFile(configAgentsFile); err == nil && len(content) > 0 {
 			info.InjectFiles = append(info.InjectFiles, configAgentsFile)
 			info.InjectFileContents[configAgentsFile] = string(content)
 			seenFiles[strings.ToLower(configAgentsFile)] = true
 		}
-		// Also check legacy ~/.shelley/AGENTS.md location
+	}
+	// Also check legacy ~/.shelley/AGENTS.md location
+	if home, err := os.UserHomeDir(); err == nil {
 		shelleyAgentsFile := filepath.Join(home, ".shelley", "AGENTS.md")
 		if content, err := os.ReadFile(shelleyAgentsFile); err == nil && len(content) > 0 {
 			lowerPath := strings.ToLower(shelleyAgentsFile)


### PR DESCRIPTION
- Add new paths package with ConfigHome(), ShelleyConfigDir(), and ExpandPath() functions for proper XDG Base Directory support
- Modify skills.DefaultDirs() to search three locations in precedence order:
	1. $XDG_CONFIG_HOME/shelley/ (shelley-specific, highest precedence)
	2. ~/.shelley/ (legacy location)
	3. $XDG_CONFIG_HOME/agents/skills (shared across agents)
- Update skills.Discover() to deduplicate by skill name (not just path), ensuring earlier directories take precedence for same-named skills
- Update server/system_prompt.go to use paths.ShelleyConfigDir() for AGENTS.md
- Add tests for precedence behavior and paths package

This allows sharing skills between shelley and other agents (octofriend, crush, amp) while still allowing shelley-specific overrides.

Fixes: #68