### PR TITLE
fix: copy to clipboard in non-secure contexts (HTTP on non-localhost)

### DIFF
--- a/slug/slug.go
+++ b/slug/slug.go
@@ -149,11 +149,19 @@ Respond with only the slug, nothing else.`, userMessage)
 		return "", fmt.Errorf("failed to generate slug: %w", err)
 	}
 
-	if len(response.Content) == 0 {
-		return "", fmt.Errorf("empty response from LLM")
+	// Find the first text content block, skipping thinking blocks
+	var rawSlug string
+	for _, c := range response.Content {
+		if c.Type == llm.ContentTypeText && c.Text != "" {
+			rawSlug = c.Text
+			break
+		}
+	}
+	if rawSlug == "" {
+		return "", fmt.Errorf("no text content in LLM response")
 	}
 
-	slug := strings.TrimSpace(response.Content[0].Text)
+	slug := strings.TrimSpace(rawSlug)
 	slug = Sanitize(slug)
 	if slug == "" {
 		return "", fmt.Errorf("generated slug is empty after sanitization")

--- a/ui/src/components/Message.tsx
+++ b/ui/src/components/Message.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import { copyToClipboard } from "../utils/clipboard";
 import { linkifyText } from "../utils/linkify";
 import {
   Message as MessageType,
@@ -124,7 +125,7 @@ function GitInfoMessage({
   const handleCopyHash = (e: React.MouseEvent) => {
     e.preventDefault();
     if (commitHash) {
-      navigator.clipboard.writeText(commitHash).then(() => {
+      copyToClipboard(commitHash).then(() => {
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
       });
@@ -419,7 +420,7 @@ function Message({ message, onOpenDiffViewer, onCommentTextChange }: MessageProp
   const handleCopy = () => {
     const text = getMessageText();
     if (text) {
-      navigator.clipboard.writeText(text).catch((err) => {
+      copyToClipboard(text).catch((err) => {
         console.error("Failed to copy text:", err);
       });
     }

--- a/ui/src/components/TerminalPanel.tsx
+++ b/ui/src/components/TerminalPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { copyToClipboard } from "../utils/clipboard";
 import { isDarkModeActive } from "../services/theme";
 import "@xterm/xterm/css/xterm.css";
 
@@ -441,12 +442,12 @@ export default function TerminalPanel({
   );
 
   const copyScreen = useCallback(() => {
-    navigator.clipboard.writeText(getBufferText("screen"));
+    copyToClipboard(getBufferText("screen"));
     showFeedback("copyScreen");
   }, [getBufferText, showFeedback]);
 
   const copyAll = useCallback(() => {
-    navigator.clipboard.writeText(getBufferText("all"));
+    copyToClipboard(getBufferText("all"));
     showFeedback("copyAll");
   }, [getBufferText, showFeedback]);
 

--- a/ui/src/utils/clipboard.ts
+++ b/ui/src/utils/clipboard.ts
@@ -1,0 +1,21 @@
+// Copy text to clipboard.
+// Uses the modern Clipboard API when available (secure contexts),
+// otherwise falls back to execCommand for non-secure contexts (e.g. HTTP on non-localhost).
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text);
+  }
+
+  // Non-secure context: use textarea + execCommand
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}


### PR DESCRIPTION
## Human Comment

Hi, thanks for Shelley, I've been loving it. I am running it on a personal machine and accessing via tailscale, so I ran into this clipboard issue since the browser thinks it's not a secure connection.

## Problem

`navigator.clipboard` is `undefined` in non-secure contexts (plain HTTP on a non-localhost hostname). The code called `navigator.clipboard.writeText(text).catch(...)`, but since `navigator.clipboard` was `undefined`, it threw a synchronous `TypeError` before any Promise was created — the `.catch()` never ran. Silent failure, nothing copied.

## Fix

Added a `copyToClipboard()` utility (`ui/src/utils/clipboard.ts`) that:
1. Uses `navigator.clipboard.writeText()` when available (secure contexts)
2. Falls back to `textarea` + `execCommand('copy')` otherwise

Updated all 4 clipboard write call sites:
- Message copy action
- Commit hash copy  
- Terminal panel copy screen/copy all buttons