### PR TITLE
Add highlight to navigated user messages (Ctrl/Cmd+M, P/N)

### DIFF
--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -717,7 +717,12 @@ function ChatInterface({
     }
 
     targetIdx = Math.max(0, Math.min(targetIdx, userMessageEls.length - 1));
-    userMessageEls[targetIdx].scrollIntoView({ behavior: "smooth", block: "start" });
+
+    // Remove highlight from all prompts, then add to target
+    userMessageEls.forEach((el) => el.classList.remove("prompt-highlighted"));
+    const targetEl = userMessageEls[targetIdx];
+    targetEl.classList.add("prompt-highlighted");
+    targetEl.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [navigateUserMessageTrigger]);
 
   // Load messages and set up streaming

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -594,6 +594,13 @@ button {
   color: var(--user-message-text);
 }
 
+/* Highlighted prompt (Ctrl+Up/Down navigation) */
+.message-user.prompt-highlighted .message-content {
+  outline: 2px solid var(--blue-text);
+  outline-offset: 4px;
+  border-radius: 0.5rem;
+}
+
 .message-agent .message-content,
 .message-tool .message-content {
   margin-right: auto;


### PR DESCRIPTION
Adds a blue outline highlight to the currently targeted user message when navigating with the Ctrl/Cmd+M chord shortcuts, for easier visual discernment.