### PR TITLE
shelley/ui: fix message input not focused on page load

### DIFF
--- a/ui/src/components/MessageInput.tsx
+++ b/ui/src/components/MessageInput.tsx
@@ -384,13 +384,16 @@ function MessageInput({
   }, [message, persistKey]);
 
   useEffect(() => {
-    if (autoFocus && textareaRef.current) {
+    // Guard on !disabled (and depend on disabled) so focus is re-attempted
+    // when the textarea becomes enabled — on page load it's briefly disabled
+    // while messages load.
+    if (autoFocus && !disabled && textareaRef.current) {
       // Use setTimeout to ensure the component is fully rendered
       setTimeout(() => {
         textareaRef.current?.focus();
       }, 0);
     }
-  }, [autoFocus]);
+  }, [autoFocus, disabled]);
 
   // Handle virtual keyboard appearance on mobile (especially Android Firefox)
   // The visualViewport API lets us detect when the keyboard shrinks the viewport


### PR DESCRIPTION
The autoFocus useEffect fired with setTimeout(0) while the textarea was still disabled (loading=true), so the browser ignored the focus() call. When loading completed and the textarea became enabled, nothing re-triggered focus.

Fix: add 'disabled' to the useEffect dependency array so focus is attempted again when the textarea transitions from disabled to enabled.