### PR TITLE
Allow Cmd/Ctrl+Enter to send on mobile

### DIFF
--- a/ui/src/components/MessageInput.tsx
+++ b/ui/src/components/MessageInput.tsx
@@ -342,7 +342,7 @@ function MessageInput({
       // I'm not convinced the divergence from desktop is the correct answer,
       // but we can try it and see how it feels.
       const isMobile = "ontouchstart" in window;
-      if (isMobile) {
+      if (isMobile && !(e.ctrlKey || e.metaKey)) {
         return;
       }
       e.preventDefault();


### PR DESCRIPTION
- Enter on mobile soft keyboard still inserts a line
- Shift+Enter inserts a line on any platform  
- Cmd+Enter or Ctrl+Enter now sends on mobile too

Fixes #59