### PR TITLE
server: expand @file references in guidance files

### DIFF
--- a/server/system_prompt.go
+++ b/server/system_prompt.go
@@ -199,13 +199,122 @@ func collectGitInfo(dir string) (*GitInfo, error) {
 	}, nil
 }
 
+// atFileRe matches @path tokens preceded by whitespace, an opening delimiter, or
+// start-of-line. This excludes email addresses (e.g. user@host has no leading
+// whitespace before the @). Square bracket [ is intentionally excluded: [@file](url)
+// is a Markdown hyperlink and should not be treated as a file reference.
+var atFileRe = regexp.MustCompile(`(?:^|[\s({<])@(\S+)`)
+
+// stripInlineCode replaces the contents of backtick spans with spaces so that
+// @refs inside inline code are not extracted. An unclosed span extends to end of line.
+func stripInlineCode(line string) string {
+	var b strings.Builder
+	inCode := false
+	for i := 0; i < len(line); i++ {
+		if line[i] == '`' {
+			inCode = !inCode
+			b.WriteByte(' ')
+		} else if inCode {
+			b.WriteByte(' ')
+		} else {
+			b.WriteByte(line[i])
+		}
+	}
+	return b.String()
+}
+
+// resolveAtPath resolves a raw @-reference token to an absolute path.
+// Returns "" if the token is not a recognisable path form (e.g. starts with @ or #).
+func resolveAtPath(raw, fromFile string) string {
+	switch {
+	case strings.HasPrefix(raw, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return filepath.Clean(filepath.Join(home, raw[2:]))
+	case filepath.IsAbs(raw):
+		return filepath.Clean(raw)
+	case len(raw) > 0 && isAtPathStart(raw[0]):
+		return filepath.Clean(filepath.Join(filepath.Dir(fromFile), raw))
+	default:
+		return ""
+	}
+}
+
+// isAtPathStart returns true for characters that may begin a valid path token:
+// word characters, dot (for ./rel and bare names), slash, or tilde.
+func isAtPathStart(c byte) bool {
+	return c == '.' || c == '/' || c == '~' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '_' || c == '-'
+}
+
+// atPathsInContent extracts the absolute paths of all @file references in content.
+// It skips fenced code blocks (``` or ~~~) and inline backtick spans so that @refs
+// inside code are not followed. fromFile is the absolute path of the containing file
+// and is used to resolve relative references.
+func atPathsInContent(content, fromFile string) []string {
+	var paths []string
+	inFence := false
+	for _, line := range strings.Split(content, "\n") {
+		// Track fenced code block boundaries (``` or ~~~).
+		if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		for _, m := range atFileRe.FindAllStringSubmatch(stripInlineCode(line), -1) {
+			raw := m[1]
+			// Strip trailing punctuation unlikely to be part of a filename.
+			raw = strings.TrimRight(raw, ".,):!?")
+			// Strip URL-style fragment suffix.
+			if i := strings.Index(raw, "#"); i != -1 {
+				raw = raw[:i]
+			}
+			if p := resolveAtPath(raw, fromFile); p != "" {
+				paths = append(paths, p)
+			}
+		}
+	}
+	return paths
+}
+
+// addGuidanceFile loads the file at path into info if it has not been seen before,
+// then follows any @file references in its content. seen (keyed on lowercased path,
+// matching the existing convention in collectCodebaseInfo) prevents loading the same
+// file twice and is the sole cycle-detection mechanism — no depth limit is needed.
+func addGuidanceFile(path string, info *CodebaseInfo, seen map[string]bool) {
+	key := strings.ToLower(path)
+	if seen[key] {
+		return
+	}
+	content, err := os.ReadFile(path)
+	// Mark seen immediately after reading, even if content is empty, so repeated
+	// references to the same missing or empty file do not cause redundant reads.
+	seen[key] = true
+	if err != nil || len(content) == 0 {
+		return
+	}
+	info.InjectFiles = append(info.InjectFiles, path)
+	info.InjectFileContents[path] = string(content)
+	// Follow @file references found in this file. The shared seen map ensures
+	// that cycles (e.g. a child referencing its parent) terminate naturally.
+	for _, ref := range atPathsInContent(string(content), path) {
+		addGuidanceFile(ref, info, seen)
+	}
+}
+
 func collectCodebaseInfo(wd string, gitInfo *GitInfo) (*CodebaseInfo, error) {
 	info := &CodebaseInfo{
 		InjectFiles:        []string{},
 		InjectFileContents: make(map[string]string),
 	}
 
-	// Track seen files to avoid duplicates on case-insensitive file systems
+	// Track seen files to avoid duplicates on case-insensitive file systems.
+	// The same map is reused for @file reference expansion in addGuidanceFile.
 	seenFiles := make(map[string]bool)
 
 	// Check for user-level agent instructions in ~/.config/AGENTS.md, ~/.config/shelley/AGENTS.md, and ~/.shelley/AGENTS.md
@@ -216,15 +325,7 @@ func collectCodebaseInfo(wd string, gitInfo *GitInfo) (*CodebaseInfo, error) {
 			filepath.Join(home, ".shelley", "AGENTS.md"),
 		}
 		for _, f := range userAgentsFiles {
-			lowerPath := strings.ToLower(f)
-			if seenFiles[lowerPath] {
-				continue
-			}
-			if content, err := os.ReadFile(f); err == nil && len(content) > 0 {
-				info.InjectFiles = append(info.InjectFiles, f)
-				info.InjectFileContents[f] = string(content)
-				seenFiles[lowerPath] = true
-			}
+			addGuidanceFile(f, info, seenFiles)
 		}
 	}
 
@@ -235,36 +336,14 @@ func collectCodebaseInfo(wd string, gitInfo *GitInfo) (*CodebaseInfo, error) {
 	}
 
 	// Find root-level guidance files (case-insensitive)
-	rootGuidanceFiles := findGuidanceFilesInDir(searchRoot)
-	for _, file := range rootGuidanceFiles {
-		lowerPath := strings.ToLower(file)
-		if seenFiles[lowerPath] {
-			continue
-		}
-		seenFiles[lowerPath] = true
-
-		content, err := os.ReadFile(file)
-		if err == nil && len(content) > 0 {
-			info.InjectFiles = append(info.InjectFiles, file)
-			info.InjectFileContents[file] = string(content)
-		}
+	for _, file := range findGuidanceFilesInDir(searchRoot) {
+		addGuidanceFile(file, info, seenFiles)
 	}
 
 	// If working directory is different from root, also check working directory
 	if wd != searchRoot {
-		wdGuidanceFiles := findGuidanceFilesInDir(wd)
-		for _, file := range wdGuidanceFiles {
-			lowerPath := strings.ToLower(file)
-			if seenFiles[lowerPath] {
-				continue
-			}
-			seenFiles[lowerPath] = true
-
-			content, err := os.ReadFile(file)
-			if err == nil && len(content) > 0 {
-				info.InjectFiles = append(info.InjectFiles, file)
-				info.InjectFileContents[file] = string(content)
-			}
+		for _, file := range findGuidanceFilesInDir(wd) {
+			addGuidanceFile(file, info, seenFiles)
 		}
 	}
 

--- a/server/system_prompt.txt
+++ b/server/system_prompt.txt
@@ -39,8 +39,8 @@ AGENTS.md/CLAUDE.md contain project conventions. Root-level contents included be
 </customization>
 {{if .Codebase.InjectFiles}}
 <guidance>
-{{range .Codebase.InjectFiles}}<root_guidance file="{{.}}">
-{{index $.Codebase.InjectFileContents .}}
+{{range .Codebase.InjectFiles}}<root_guidance file="{{.Path}}"{{if .ImportedBy}} imported_by="{{.ImportedBy}}"{{end}}>
+{{.Content}}
 </root_guidance>
 {{end}}</guidance>
 {{end}}

--- a/server/system_prompt_at_file_test.go
+++ b/server/system_prompt_at_file_test.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helpers
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// --- atPathsInContent ---
+
+func TestAtPathsInContent_InlineMidSentence(t *testing.T) {
+	paths := atPathsInContent("See @notes.md for details.", "/proj/AGENTS.md")
+	if len(paths) != 1 || filepath.Base(paths[0]) != "notes.md" {
+		t.Errorf("expected [notes.md], got %v", paths)
+	}
+}
+
+func TestAtPathsInContent_MultipleOnOneLine(t *testing.T) {
+	paths := atPathsInContent("Read @file1.md and @file2.md please.", "/proj/AGENTS.md")
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %v", paths)
+	}
+	if filepath.Base(paths[0]) != "file1.md" || filepath.Base(paths[1]) != "file2.md" {
+		t.Errorf("unexpected paths: %v", paths)
+	}
+}
+
+func TestAtPathsInContent_SkipsFencedBlock(t *testing.T) {
+	content := "before\n```\ncode @secret.md\n```\nafter"
+	for _, p := range atPathsInContent(content, "/proj/AGENTS.md") {
+		if strings.Contains(p, "secret") {
+			t.Errorf("should not extract @secret.md from inside fenced block, got %v", p)
+		}
+	}
+}
+
+func TestAtPathsInContent_SkipsFencedBlockWithLanguage(t *testing.T) {
+	content := "before\n```go\ncode @secret.md\n```\nafter"
+	for _, p := range atPathsInContent(content, "/proj/AGENTS.md") {
+		if strings.Contains(p, "secret") {
+			t.Errorf("should not extract @secret.md from fenced go block, got %v", p)
+		}
+	}
+}
+
+func TestAtPathsInContent_SkipsInlineCode(t *testing.T) {
+	for _, p := range atPathsInContent("Run `@secret.md` to see.", "/proj/AGENTS.md") {
+		if strings.Contains(p, "secret") {
+			t.Errorf("should not extract @secret.md from inline code, got %v", p)
+		}
+	}
+}
+
+func TestAtPathsInContent_IgnoresEmail(t *testing.T) {
+	paths := atPathsInContent("Contact user@example.com for help.", "/proj/AGENTS.md")
+	if len(paths) != 0 {
+		t.Errorf("expected no paths from email address, got %v", paths)
+	}
+}
+
+func TestAtPathsInContent_TrailingPunctuation(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"See @rules.md.", "rules.md"},
+		{"Read @rules.md,", "rules.md"},
+		{"Use @rules.md:", "rules.md"},
+		{"(@rules.md)", "rules.md"},
+	}
+	for _, tc := range cases {
+		paths := atPathsInContent(tc.input, "/proj/AGENTS.md")
+		if len(paths) != 1 || filepath.Base(paths[0]) != tc.want {
+			t.Errorf("input %q: expected [%s], got %v", tc.input, tc.want, paths)
+		}
+	}
+}
+
+func TestAtPathsInContent_MarkdownLinkIgnored(t *testing.T) {
+	// [@file.md](url) is a Markdown hyperlink — the @ref should not be followed.
+	// The "]( " suffix is stripped explicitly before path resolution.
+	paths := atPathsInContent("[@rules.md](https://example.com)", "/proj/AGENTS.md")
+	for _, p := range paths {
+		if strings.Contains(p, "rules") {
+			t.Errorf("Markdown hyperlink @ref should not be followed, got %v", p)
+		}
+	}
+}
+
+func TestAtPathsInContent_FragmentStripped(t *testing.T) {
+	paths := atPathsInContent("See @file.md#section for more.", "/proj/AGENTS.md")
+	if len(paths) != 1 || filepath.Base(paths[0]) != "file.md" {
+		t.Errorf("expected [file.md], got %v", paths)
+	}
+}
+
+func TestAtPathsInContent_AllPathForms(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	cases := []struct{ input, want string }{
+		{"@./rel.md", "/base/rel.md"},
+		{"@../up.md", "/up.md"},
+		{"@bare.md", "/base/bare.md"},
+		{"@/abs/path.md", "/abs/path.md"},
+		{"@~/home/notes.md", filepath.Join(home, "home/notes.md")},
+	}
+	for _, tc := range cases {
+		paths := atPathsInContent(tc.input, "/base/AGENTS.md")
+		if len(paths) != 1 || paths[0] != tc.want {
+			t.Errorf("input %q: expected [%s], got %v", tc.input, tc.want, paths)
+		}
+	}
+}
+
+func TestAtPathsInContent_InsideParens(t *testing.T) {
+	paths := atPathsInContent("(see @file.md)", "/proj/AGENTS.md")
+	if len(paths) != 1 || filepath.Base(paths[0]) != "file.md" {
+		t.Errorf("expected [file.md] from parenthesised ref, got %v", paths)
+	}
+}
+
+func TestAtPathsInContent_HomeDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	paths := atPathsInContent("@~/notes.md", "/any/AGENTS.md")
+	want := filepath.Join(home, "notes.md")
+	if len(paths) != 1 || paths[0] != want {
+		t.Errorf("expected [%s], got %v", want, paths)
+	}
+}
+
+func TestAtPathsInContent_RejectsInvalidPaths(t *testing.T) {
+	for _, input := range []string{
+		"tag @#heading",
+		"at sign @@@foo",
+	} {
+		if paths := atPathsInContent(input, "/proj/AGENTS.md"); len(paths) != 0 {
+			t.Errorf("input %q: expected no paths, got %v", input, paths)
+		}
+	}
+}
+
+// --- addGuidanceFile ---
+
+func TestAddGuidanceFile_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "Hello @notes.md end")
+	writeFile(t, filepath.Join(dir, "notes.md"), "My notes")
+
+	info := &CodebaseInfo{InjectFileContents: make(map[string]string)}
+	addGuidanceFile(filepath.Join(dir, "AGENTS.md"), info, make(map[string]bool))
+
+	if len(info.InjectFiles) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(info.InjectFiles), info.InjectFiles)
+	}
+	if filepath.Base(info.InjectFiles[0]) != "AGENTS.md" {
+		t.Errorf("first entry should be AGENTS.md, got %s", info.InjectFiles[0])
+	}
+	if filepath.Base(info.InjectFiles[1]) != "notes.md" {
+		t.Errorf("second entry should be notes.md, got %s", info.InjectFiles[1])
+	}
+	if info.InjectFileContents[info.InjectFiles[1]] != "My notes" {
+		t.Errorf("unexpected content for notes.md: %q", info.InjectFileContents[info.InjectFiles[1]])
+	}
+}
+
+func TestAddGuidanceFile_CircularIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.md"), "I am A, see @b.md")
+	writeFile(t, filepath.Join(dir, "b.md"), "I am B, see @a.md")
+
+	info := &CodebaseInfo{InjectFileContents: make(map[string]string)}
+	addGuidanceFile(filepath.Join(dir, "a.md"), info, make(map[string]bool))
+
+	if len(info.InjectFiles) != 2 {
+		t.Fatalf("expected 2 files (no infinite loop), got %d", len(info.InjectFiles))
+	}
+	seen := map[string]int{}
+	for _, f := range info.InjectFiles {
+		seen[f]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("%s loaded %d times, expected 1", path, count)
+		}
+	}
+}
+
+func TestAddGuidanceFile_ChainFollowed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.md"), "I am A, see @b.md")
+	writeFile(t, filepath.Join(dir, "b.md"), "I am B, see @c.md")
+	writeFile(t, filepath.Join(dir, "c.md"), "I am C")
+
+	info := &CodebaseInfo{InjectFileContents: make(map[string]string)}
+	addGuidanceFile(filepath.Join(dir, "a.md"), info, make(map[string]bool))
+
+	if len(info.InjectFiles) != 3 {
+		t.Fatalf("expected 3 files in chain, got %d", len(info.InjectFiles))
+	}
+	for i, want := range []string{"a.md", "b.md", "c.md"} {
+		if filepath.Base(info.InjectFiles[i]) != want {
+			t.Errorf("position %d: expected %s, got %s", i, want, filepath.Base(info.InjectFiles[i]))
+		}
+	}
+}
+
+func TestAddGuidanceFile_MissingRefSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "See @nonexistent.md for details")
+
+	info := &CodebaseInfo{InjectFileContents: make(map[string]string)}
+	addGuidanceFile(filepath.Join(dir, "AGENTS.md"), info, make(map[string]bool))
+
+	if len(info.InjectFiles) != 1 {
+		t.Errorf("expected 1 file (missing ref skipped), got %d: %v", len(info.InjectFiles), info.InjectFiles)
+	}
+}
+
+func TestAddGuidanceFile_Deduplication(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.md"), "A imports @shared.md")
+	writeFile(t, filepath.Join(dir, "b.md"), "B imports @shared.md")
+	writeFile(t, filepath.Join(dir, "shared.md"), "I am shared")
+
+	info := &CodebaseInfo{InjectFileContents: make(map[string]string)}
+	seen := make(map[string]bool)
+	addGuidanceFile(filepath.Join(dir, "a.md"), info, seen)
+	addGuidanceFile(filepath.Join(dir, "b.md"), info, seen)
+
+	// a.md + shared.md + b.md = 3; shared.md must appear exactly once
+	if len(info.InjectFiles) != 3 {
+		t.Fatalf("expected 3 files, got %d: %v", len(info.InjectFiles), info.InjectFiles)
+	}
+	count := 0
+	for _, f := range info.InjectFiles {
+		if filepath.Base(f) == "shared.md" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("shared.md should appear exactly once, appeared %d times", count)
+	}
+}
+
+// --- integration ---
+
+func TestSystemPrompt_AtFileIncluded(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "Rules: see @extra.md for more.")
+	writeFile(t, filepath.Join(dir, "extra.md"), "EXTRA_UNIQUE_CONTENT_99887")
+
+	prompt, err := GenerateSystemPrompt(dir)
+	if err != nil {
+		t.Fatalf("GenerateSystemPrompt: %v", err)
+	}
+	if !strings.Contains(prompt, "EXTRA_UNIQUE_CONTENT_99887") {
+		t.Error("imported file content should appear in the system prompt")
+	}
+	if !strings.Contains(prompt, filepath.Join(dir, "extra.md")) {
+		t.Error("imported file path should appear in the system prompt")
+	}
+}


### PR DESCRIPTION
Guidance files (AGENTS.md, CLAUDE.md, etc.) may now reference other files with @path syntax. Referenced files are loaded and included in the system prompt as additional <root_guidance> entries alongside the parent. References inside imported files are followed by the same rule.

## Examples

A user-level AGENTS.md can split out frequently-updated notes:

    # ~/.config/shelley/AGENTS.md
    You are running on an exe.dev VM.
    @notes.md

    # ~/.config/shelley/notes.md
    ## Current project
    Working on the payments service refactor.

Both files appear as separate <root_guidance> blocks in the system prompt.

References work anywhere in the line as long as @ is preceded by whitespace:

    See @rules.md for coding standards.
    Important: read @./context/background.md before starting.

All path forms are supported:

    @bare.md           # relative to the containing file's directory
    @./explicit.md     # same
    @../parent.md      # parent directory
    @/absolute/path.md # absolute
    @~/notes.md        # home directory

References inside fenced code blocks and inline backtick spans are ignored:

    ```
    @this-is-not-a-reference.md
    ```

    Use `@ref` syntax to import files.  <- also ignored

Markdown hyperlinks are not followed ([ excluded from the leading set):

    [@file.md](https://example.com)  <- not imported

## Implementation

- Extract the repeated file-loading pattern in collectCodebaseInfo into addGuidanceFile, which also follows @refs in the loaded content. The shared seen map prevents loading the same file twice and handles cycles naturally without a depth limit.
- atPathsInContent extracts @ref paths from content, skipping fenced code blocks and inline backtick spans.
- resolveAtPath resolves a raw token to an absolute path, supporting ~/, absolute, and relative forms.

19 tests in server/system_prompt_at_file_test.go.