### PR TITLE
fix(ui): keep active conversation in git group during streaming updates

### DIFF
--- a/ui/e2e/conversation-grouping.spec.ts
+++ b/ui/e2e/conversation-grouping.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+async function createConversation(
+  request: import("@playwright/test").APIRequestContext,
+  message: string,
+): Promise<{ conversation_id: string; slug: string }> {
+  const resp = await request.post("/api/conversations/new", {
+    data: { message, model: "predictable", cwd: "/home/exedev/shelley" },
+  });
+  expect(resp.ok()).toBeTruthy();
+  const { conversation_id } = await resp.json();
+
+  let slug = "";
+  await expect(async () => {
+    const conv = await request.get(`/api/conversation/${conversation_id}`);
+    const body = await conv.json();
+    const hasAgent = body.messages?.some((m: { type: string }) => m.type === "agent");
+    expect(hasAgent).toBeTruthy();
+    slug = body.conversation?.slug || "";
+    expect(slug).toBeTruthy();
+  }).toPass({ timeout: 15000 });
+
+  return { conversation_id, slug };
+}
+
+test.describe("Conversation grouping", () => {
+  test("active conversation should not be grouped under Other when grouped by git repo", async ({
+    page,
+    request,
+  }) => {
+    await createConversation(request, "Hello from conversation A");
+    const active = await createConversation(request, "Hello from conversation B");
+
+    await page.goto(`/c/${active.slug}`);
+    await expect(page.getByTestId("message-input")).toBeVisible({ timeout: 30000 });
+
+    // Open drawer and enable grouping by git repo.
+    await page.locator('button[aria-label="Open conversations"]').click();
+    await expect(page.locator(".drawer.open")).toBeVisible();
+    await page.locator('button[aria-label="Group conversations"]').click();
+    await page.getByRole("button", { name: "Git Repo" }).click();
+
+    // The group containing the active conversation should not be "Other".
+    const activeGroup = page.locator(".conversation-group").filter({
+      has: page.locator(".conversation-item.active"),
+    });
+    await expect(activeGroup).toHaveCount(1);
+
+    const activeGroupLabel = (await activeGroup.locator(".conversation-group-label").innerText()).trim();
+    expect(activeGroupLabel).not.toBe("Other");
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -506,10 +506,15 @@ function App() {
         conv.conversation_id === updatedConversation.conversation_id
           ? {
               ...updatedConversation,
+              // Preserve list-level state fields maintained elsewhere
               working: conv.working,
+              subagent_count: conv.subagent_count,
+              // Preserve git metadata from conversation list updates.
+              // Stream conversation updates don't include these fields.
+              git_repo_root: conv.git_repo_root,
+              git_worktree_root: conv.git_worktree_root,
               git_commit: conv.git_commit,
               git_subject: conv.git_subject,
-              subagent_count: conv.subagent_count,
             }
           : conv,
       ),


### PR DESCRIPTION
When grouping conversations by git repo, the selected conversation could jump to "Other" after stream-driven metadata updates.

Root cause:
- App.updateConversation() merged stream conversation payloads into the list entry.
- Stream payloads do not include list-level git grouping fields (git_repo_root/git_worktree_root).
- Those fields were inadvertently dropped for the selected conversation, causing ConversationDrawer's git grouping key to become null and the item to be rendered under "Other".

Fix:
- Preserve git_repo_root and git_worktree_root when applying onConversationUpdate merges in App.tsx.
- Continue preserving existing list-owned fields (working, subagent_count, git_commit, git_subject).

Regression test:
- Add ui/e2e/conversation-grouping.spec.ts
- Reproduces the bug by selecting git grouping and asserting the active conversation's containing group is not "Other".

Validation:
- ui type-check + lint
- e2e test conversation-grouping.spec.ts