### PR TITLE
ui/e2e: derive grouping test cwd from invoking git repo

### DIFF
--- a/ui/e2e/conversation-grouping.spec.ts
+++ b/ui/e2e/conversation-grouping.spec.ts
@@ -1,11 +1,14 @@
+import { execSync } from "node:child_process";
 import { test, expect } from "@playwright/test";
+
+const testRepoRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
 
 async function createConversation(
   request: import("@playwright/test").APIRequestContext,
   message: string,
 ): Promise<{ conversation_id: string; slug: string }> {
   const resp = await request.post("/api/conversations/new", {
-    data: { message, model: "predictable", cwd: "/home/exedev/shelley" },
+    data: { message, model: "predictable", cwd: testRepoRoot },
   });
   expect(resp.ok()).toBeTruthy();
   const { conversation_id } = await resp.json();


### PR DESCRIPTION
The conversation-grouping e2e test was hardcoding /home/exedev/shelley as cwd when creating conversations. That made the test environment-dependent and wrong when Shelley is checked out elsewhere.

Compute cwd via 'git rev-parse --show-toplevel' at test startup and pass that to /api/conversations/new. This keeps the test tied to the repo it is launched from (including launches from subdirectories) and preserves the intent of git-repo grouping assertions.