### PR TITLE
fix: match exact cancellation sentinel in BashTool UI

### DIFF
--- a/ui/src/components/BashTool.tsx
+++ b/ui/src/components/BashTool.tsx
@@ -85,7 +85,7 @@ function BashTool({
     toolResult && toolResult.length > 0 && toolResult[0].Text ? toolResult[0].Text : "";
 
   // Check if this was a cancelled operation
-  const isCancelled = hasError && output.toLowerCase().includes("cancel");
+  const isCancelled = hasError && output.includes("Tool execution cancelled by user");
 
   // Truncate command for display
   const truncateCommand = (cmd: string, maxLen: number = 300) => {


### PR DESCRIPTION
The 'cancelled' badge was shown for any bash error containing the word 'cancel' (case-insensitive), which false-positives on errors like 'context canceled'. Now we match the exact sentinel string 'Tool execution cancelled by user' that the server records on user-initiated cancellation.