### PR TITLE
add plan mode, mid-turn message injection, and FlexBool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,4 @@
       reads the `action` field from the input and dispatches to the right sub-component)
     - `loop/predictable.go` (the "tool smorgasbord" demo response)
     - See `ui/src/components/AGENTS.md` for more detail.
+16. Prefer `wait: false` for subagents doing background research. Use `wait: true` only when you need the result to continue, and keep timeouts short (30s max). Never block the conversation for minutes.

--- a/claudetool/bash.go
+++ b/claudetool/bash.go
@@ -143,7 +143,7 @@ For complex scripts, write them to a file first and then execute the file.
 
 type bashInput struct {
 	Command string `json:"command"`
-	SlowOK  bool   `json:"slow_ok,omitempty"`
+	SlowOK  FlexBool `json:"slow_ok,omitempty"`
 }
 
 // BashDisplayData is the display data sent to the UI for bash tool results.

--- a/claudetool/shared.go
+++ b/claudetool/shared.go
@@ -7,9 +7,26 @@ package claudetool
 
 import (
 	"context"
+	"fmt"
 
 	"shelley.exe.dev/llm"
 )
+
+// FlexBool is a bool that also accepts string values "true" and "false" in JSON.
+// LLMs sometimes send boolean values as strings.
+type FlexBool bool
+
+func (b *FlexBool) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case "true", `"true"`:
+		*b = true
+	case "false", `"false"`:
+		*b = false
+	default:
+		return fmt.Errorf("invalid bool value: %s", data)
+	}
+	return nil
+}
 
 type workingDirCtxKeyType string
 

--- a/claudetool/subagent.go
+++ b/claudetool/subagent.go
@@ -125,7 +125,7 @@ type subagentInput struct {
 	Slug           string `json:"slug"`
 	Prompt         string `json:"prompt"`
 	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
-	Wait           *bool  `json:"wait,omitempty"`
+	Wait           *FlexBool `json:"wait,omitempty"`
 	Model          string `json:"model,omitempty"`
 }
 
@@ -169,7 +169,7 @@ func (s *SubagentTool) Run(ctx context.Context, m json.RawMessage) llm.ToolOut {
 
 	wait := true
 	if req.Wait != nil {
-		wait = *req.Wait
+		wait = bool(*req.Wait)
 	}
 
 	// Determine which model to use: explicit choice > parent's model

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -45,11 +45,19 @@ type Config struct {
 	OnStreamDone func()
 }
 
+// planModeBlockedTools are tools disabled in plan mode.
+var planModeBlockedTools = map[string]bool{
+	"patch":         true,
+	"output_iframe": true,
+}
+
 // Loop manages a conversation turn with an LLM including tool execution and message recording.
 // Notably, when the turn ends, the "Loop" is over. TODO: maybe rename to Turn?
 type Loop struct {
 	llm              llm.Service
 	tools            []*llm.Tool
+	allTools         []*llm.Tool // full tool list, stored when plan mode is enabled
+	planMode         bool
 	recordMessage    MessageRecordFunc
 	history          []llm.Message
 	messageQueue     []llm.Message
@@ -111,6 +119,36 @@ func (l *Loop) QueueUserMessage(message llm.Message) {
 	case l.notify <- struct{}{}:
 	default:
 	}
+}
+
+// SetPlanMode enables or disables plan mode, filtering tools accordingly.
+func (l *Loop) SetPlanMode(enabled bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.planMode = enabled
+
+	if l.allTools == nil {
+		l.allTools = l.tools
+	}
+
+	if enabled {
+		var filtered []*llm.Tool
+		for _, t := range l.allTools {
+			if !planModeBlockedTools[t.Name] {
+				filtered = append(filtered, t)
+			}
+		}
+		l.tools = filtered
+	} else {
+		l.tools = l.allTools
+	}
+}
+
+// GetPlanMode returns whether plan mode is enabled.
+func (l *Loop) GetPlanMode() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.planMode
 }
 
 // GetUsage returns the total usage accumulated by this loop
@@ -223,7 +261,13 @@ func (l *Loop) processLLMRequest(ctx context.Context) error {
 		tools := l.tools
 		system := l.system
 		llmService := l.llm
+		inPlanMode := l.planMode
 		l.mu.Unlock()
+
+		// Append [PLAN MODE] to system prompt so the LLM knows
+		if inPlanMode {
+			system = append(append([]llm.SystemContent(nil), system...), llm.SystemContent{Type: "text", Text: "[PLAN MODE]"})
+		}
 
 		// Enable prompt caching: set cache flag on last tool and last user message content
 		// See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching

--- a/server/convo.go
+++ b/server/convo.go
@@ -69,6 +69,13 @@ type ConversationManager struct {
 	// onStateChange is called when the conversation state changes.
 	// This allows the server to broadcast state changes to all subscribers.
 	onStateChange func(state ConversationState)
+
+	// planMode is stored on the manager so it survives loop recreation.
+	planMode bool
+
+	// onDone is called when the agent finishes working (transitions to not working).
+	// Used by subagents to notify their parent conversation.
+	onDone func()
 }
 
 // NewConversationManager constructs a manager with dependencies but defers hydration until needed.
@@ -100,6 +107,7 @@ func (cm *ConversationManager) SetAgentWorking(working bool) {
 	}
 	cm.agentWorking = working
 	onStateChange := cm.onStateChange
+	onDone := cm.onDone
 	convID := cm.conversationID
 	modelID := cm.modelID
 	cm.mu.Unlock()
@@ -110,7 +118,11 @@ func (cm *ConversationManager) SetAgentWorking(working bool) {
 			ConversationID: convID,
 			Working:        working,
 			Model:          modelID,
+			PlanMode:       boolPtr(cm.GetPlanMode()),
 		})
+	}
+	if !working && onDone != nil {
+		onDone()
 	}
 }
 
@@ -135,6 +147,27 @@ func (cm *ConversationManager) GetModel() string {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	return cm.modelID
+}
+
+// SetPlanMode enables or disables plan mode, filtering tools on the active loop.
+func (cm *ConversationManager) SetPlanMode(enabled bool) {
+	cm.mu.Lock()
+	cm.planMode = enabled
+	loopInstance := cm.loop
+	cm.mu.Unlock()
+
+	if loopInstance != nil {
+		loopInstance.SetPlanMode(enabled)
+	}
+
+	cm.logger.Info("plan mode changed", "enabled", enabled)
+}
+
+// GetPlanMode returns whether plan mode is enabled.
+func (cm *ConversationManager) GetPlanMode() bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.planMode
 }
 
 // Hydrate loads conversation metadata from the database and generates a system
@@ -280,13 +313,14 @@ func (cm *ConversationManager) AcceptUserMessage(ctx context.Context, service ll
 	return isFirst, nil
 }
 
-// QueueMessage records a user message to the database as "queued" and holds it
-// for delivery after the current agent turn (or distillation) completes.
-// The message is visible in the UI immediately (with queued status).
+// QueueMessage records a user message to the database and, when the agent
+// is actively working, injects it into the loop's message queue so it gets
+// picked up between tool calls — not after the entire turn ends.
+// During distillation or when no loop exists, messages are held for later.
 func (cm *ConversationManager) QueueMessage(ctx context.Context, s *Server, modelID string, message llm.Message) error {
 	// Record to DB with queued user_data so it appears in the UI.
 	// Mark as excluded_from_context so ensureLoop won't load it into
-	// the loop's history — we'll feed it via QueueUserMessage when draining.
+	// the loop's history — we feed it via QueueUserMessage directly.
 	userData := map[string]interface{}{"queued": true}
 	createdMsg, err := s.db.CreateMessage(ctx, db.CreateMessageParams{
 		ConversationID:      cm.conversationID,
@@ -311,25 +345,59 @@ func (cm *ConversationManager) QueueMessage(ctx context.Context, s *Server, mode
 	go s.notifySubscribersNewMessage(context.WithoutCancel(ctx), cm.conversationID, createdMsg)
 
 	cm.mu.Lock()
-	cm.pendingMessages = append(cm.pendingMessages, pendingMessage{
-		Message:   message,
-		ModelID:   modelID,
-		MessageID: createdMsg.MessageID,
-	})
+	loopInstance := cm.loop
+	distilling := cm.distilling
 	cm.lastActivity = time.Now()
-	// If the agent is no longer working (and not distilling), drain immediately.
-	// This handles the race where drainPendingMessages ran (finding nothing)
-	// before this QueueMessage call appended the message.
-	// During distillation, messages must wait — the distill goroutine will drain.
-	needsDrain := !cm.agentWorking && !cm.distilling
 	cm.mu.Unlock()
 
-	cm.logger.Info("Queued user message", "message_id", createdMsg.MessageID)
+	msgID := createdMsg.MessageID
 
-	if needsDrain {
-		cm.logger.Info("Agent not working, draining immediately")
-		go cm.drainPendingMessages(s)
+	// If distilling or no loop, defer until later.
+	if distilling || loopInstance == nil {
+		cm.mu.Lock()
+		cm.pendingMessages = append(cm.pendingMessages, pendingMessage{
+			Message:   message,
+			ModelID:   modelID,
+			MessageID: msgID,
+		})
+		needsDrain := !cm.agentWorking && !cm.distilling
+		cm.mu.Unlock()
+
+		cm.logger.Info("Queued user message (deferred)", "message_id", msgID)
+
+		if needsDrain {
+			cm.logger.Info("Agent not working, draining immediately")
+			go cm.drainPendingMessages(s)
+		}
+		return nil
 	}
+
+	// Inject directly into the loop so it's picked up between tool calls.
+	loopInstance.QueueUserMessage(message)
+	cm.logger.Info("Injected user message into active loop", "message_id", msgID)
+
+	// Clear the queued/excluded flags so the message is visible in context.
+	go func() {
+		bgCtx := context.Background()
+		if err := s.db.QueriesTx(bgCtx, func(q *generated.Queries) error {
+			if err := q.UpdateMessageExcludedFromContext(bgCtx, generated.UpdateMessageExcludedFromContextParams{
+				ExcludedFromContext: false,
+				MessageID:           msgID,
+			}); err != nil {
+				return err
+			}
+			newData := `{}`
+			return q.UpdateMessageUserData(bgCtx, generated.UpdateMessageUserDataParams{
+				UserData:  &newData,
+				MessageID: msgID,
+			})
+		}); err != nil {
+			cm.logger.Error("Failed to clear queued flags", "message_id", msgID, "error", err)
+		}
+		if updatedMsg, err := s.db.GetMessageByID(bgCtx, msgID); err == nil {
+			s.broadcastMessageUpdate(bgCtx, cm.conversationID, updatedMsg)
+		}
+	}()
 
 	return nil
 }
@@ -845,7 +913,13 @@ func (cm *ConversationManager) ensureLoop(service llm.Service, modelID string) e
 	cm.loopCtx = processCtx
 	cm.modelID = modelID
 	cm.toolSet = toolSet
+	restoredPlanMode := cm.planMode
 	cm.mu.Unlock()
+
+	// Restore plan mode if it was set before loop recreation
+	if restoredPlanMode {
+		loopInstance.SetPlanMode(true)
+	}
 
 	// Persist model for legacy conversations
 	if needsPersist {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -615,6 +615,12 @@ func (s *Server) conversationMux() *http.ServeMux {
 	mux.HandleFunc("POST /{id}/cancel-queued", func(w http.ResponseWriter, r *http.Request) {
 		s.handleCancelQueued(w, r, r.PathValue("id"))
 	})
+	mux.HandleFunc("GET /{id}/plan-mode", func(w http.ResponseWriter, r *http.Request) {
+		s.handleGetPlanMode(w, r, r.PathValue("id"))
+	})
+	mux.HandleFunc("POST /{id}/plan-mode", func(w http.ResponseWriter, r *http.Request) {
+		s.handleSetPlanMode(w, r, r.PathValue("id"))
+	})
 	return mux
 }
 
@@ -1695,4 +1701,52 @@ func (s *Server) handleCancelQueued(w http.ResponseWriter, r *http.Request, conv
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleGetPlanMode(w http.ResponseWriter, r *http.Request, conversationID string) {
+	s.mu.Lock()
+	manager, ok := s.activeConversations[conversationID]
+	s.mu.Unlock()
+
+	planMode := false
+	if ok {
+		planMode = manager.GetPlanMode()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"plan_mode": planMode})
+}
+
+func (s *Server) handleSetPlanMode(w http.ResponseWriter, r *http.Request, conversationID string) {
+	s.mu.Lock()
+	manager, ok := s.activeConversations[conversationID]
+	s.mu.Unlock()
+
+	if !ok {
+		http.Error(w, "Conversation not found", http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	manager.SetPlanMode(body.Enabled)
+
+	// Broadcast state change so UI updates
+	if manager.onStateChange != nil {
+		manager.onStateChange(ConversationState{
+			ConversationID: conversationID,
+			Working:        manager.IsAgentWorking(),
+			Model:          manager.GetModel(),
+			PlanMode:       boolPtr(body.Enabled),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"plan_mode": body.Enabled})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -50,8 +50,11 @@ type ConversationState struct {
 	ConversationID string `json:"conversation_id"`
 	Working        bool   `json:"working"`
 	Model          string `json:"model,omitempty"`
+	PlanMode       *bool  `json:"plan_mode,omitempty"`
 }
 
+
+func boolPtr(b bool) *bool { return &b }
 // ConversationWithState combines a conversation with its working state.
 type ConversationWithState struct {
 	generated.Conversation
@@ -742,6 +745,11 @@ func (s *Server) getOrCreateSubagentConversationManager(ctx context.Context, con
 			return nil, err
 		}
 
+		// Wire up done notification: when this subagent finishes, notify the parent.
+		manager.onDone = func() {
+			go s.notifyParentSubagentDone(conversationID)
+		}
+
 		s.activeConversations[conversationID] = manager
 		return manager, nil
 	})
@@ -749,6 +757,66 @@ func (s *Server) getOrCreateSubagentConversationManager(ctx context.Context, con
 		return nil, err
 	}
 	return manager, nil
+}
+
+// notifyParentSubagentDone injects a message into the parent conversation's loop
+// when a subagent finishes, so the parent agent knows to check results.
+func (s *Server) notifyParentSubagentDone(subagentConversationID string) {
+	ctx := context.Background()
+
+	// Look up the subagent's parent conversation ID and slug
+	var conv generated.Conversation
+	err := s.db.Queries(ctx, func(q *generated.Queries) error {
+		var err error
+		conv, err = q.GetConversation(ctx, subagentConversationID)
+		return err
+	})
+	if err != nil || conv.ParentConversationID == nil {
+		return
+	}
+
+	parentID := *conv.ParentConversationID
+	slug := "unknown"
+	if conv.Slug != nil {
+		slug = *conv.Slug
+	}
+
+	// Find the parent's loop and inject a notification
+	s.mu.Lock()
+	parentManager, ok := s.activeConversations[parentID]
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	parentManager.mu.Lock()
+	loopInstance := parentManager.loop
+	parentManager.mu.Unlock()
+	if loopInstance == nil {
+		return
+	}
+
+	// Get the subagent's last response for the notification
+	runner := NewSubagentRunner(s)
+	response, err := runner.getLastAssistantResponse(ctx, subagentConversationID)
+	if err != nil || response == "" {
+		response = "(completed, use subagent tool to read results)"
+	}
+	// Truncate long responses
+	if len(response) > 500 {
+		response = response[:500] + "..."
+	}
+
+	notification := llm.Message{
+		Role: llm.MessageRoleUser,
+		Content: []llm.Content{{
+			Type: llm.ContentTypeText,
+			Text: fmt.Sprintf("[Subagent '%s' finished]\n%s", slug, response),
+		}},
+	}
+
+	loopInstance.QueueUserMessage(notification)
+	s.logger.Info("Notified parent of subagent completion", "subagent", slug, "parent", parentID)
 }
 
 // ExtractDisplayData extracts display data from message content for storage

--- a/server/system_prompt.txt
+++ b/server/system_prompt.txt
@@ -1,5 +1,11 @@
 You are Shelley, a coding agent. Experienced software engineer and architect. Communicate with brevity. Be persistent and creative.
 
+You operate in one of two modes:
+- BUILD MODE (default): All tools available. Make changes, write code, commit.
+- PLAN MODE: Editing tools are disabled. Research, analyze, read, discuss, plan only.
+
+If "[PLAN MODE]" appears in the system prompt, you are in plan mode. If it doesn't, you are in build mode.
+
 Initial pwd: {{.WorkingDirectory}}. Can be changed with change_dir tool.
 {{if .UserEmail}}
 The user's exe.dev email is {{.UserEmail}}

--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -792,6 +792,7 @@ function ChatInterface({
   const [diffViewerCwd, setDiffViewerCwd] = useState<string | undefined>(undefined);
   const [diffCommentText, setDiffCommentText] = useState("");
   const [agentWorking, setAgentWorking] = useState(false);
+  const [planMode, setPlanMode] = useState(false);
   const [cancelling, setCancelling] = useState(false);
 
   // Detect if the conversation is currently distilling
@@ -1416,6 +1417,9 @@ function ChatInterface({
           // Update local state if this is for our conversation
           if (streamResponse.conversation_state.conversation_id === conversationId) {
             setAgentWorking(streamResponse.conversation_state.working);
+            if (streamResponse.conversation_state.plan_mode !== undefined) {
+              setPlanMode(streamResponse.conversation_state.plan_mode);
+            }
             // Update selected model from conversation (ensures consistency across sessions)
             if (streamResponse.conversation_state.model) {
               setSelectedModel(streamResponse.conversation_state.model);
@@ -1739,6 +1743,22 @@ function ChatInterface({
       setError("Failed to cancel. Please try again.");
     } finally {
       setCancelling(false);
+    }
+  };
+
+  const handleTogglePlanMode = async () => {
+    if (!conversationId) return;
+    try {
+      const resp = await fetch(`/api/conversation/${conversationId}/plan-mode`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !planMode }),
+      });
+      if (resp.ok) {
+        setPlanMode(!planMode);
+      }
+    } catch (err) {
+      console.error("Failed to toggle plan mode:", err);
     }
   };
 
@@ -2751,24 +2771,35 @@ function ChatInterface({
 
       {/* Message input — hidden for archived conversations */}
       {!currentConversation?.archived && (
-        <MessageInput
-          key={conversationId || "new"}
-          onSend={sendMessage}
-          onQueue={queueMessage}
-          showQueueOption={!!conversationId}
-          canQueue={agentWorking && !!conversationId}
-          autoQueue={isDistilling && !!conversationId}
-          disabled={sending || loading}
-          autoFocus={true}
-          injectedText={terminalInjectedText || diffCommentText}
-          onClearInjectedText={() => {
-            setDiffCommentText("");
-            setTerminalInjectedText(null);
-          }}
-          persistKey={conversationId || "new-conversation"}
-          initialRows={conversationId ? 1 : 3}
-          statusSlot={conversationId && isMobile ? renderStatusContent() : undefined}
-        />
+        <div className="message-input-row">
+          <MessageInput
+            key={conversationId || "new"}
+            onSend={sendMessage}
+            onQueue={queueMessage}
+            showQueueOption={!!conversationId}
+            canQueue={agentWorking && !!conversationId}
+            autoQueue={isDistilling && !!conversationId}
+            disabled={sending || loading}
+            autoFocus={true}
+            injectedText={terminalInjectedText || diffCommentText}
+            onClearInjectedText={() => {
+              setDiffCommentText("");
+              setTerminalInjectedText(null);
+            }}
+            persistKey={conversationId || "new-conversation"}
+            initialRows={conversationId ? 1 : 3}
+            statusSlot={conversationId && isMobile ? renderStatusContent() : undefined}
+          />
+          {conversationId && (
+            <button
+              className="plan-mode-toggle"
+              onClick={handleTogglePlanMode}
+              title={planMode ? "Switch to Build Mode" : "Switch to Plan Mode"}
+            >
+              {planMode ? "[PLAN MODE]" : "[BUILD MODE]"}
+            </button>
+          )}
+        </div>
       )}
 
       {/* Directory Picker Modal */}

--- a/ui/src/generated-types.ts
+++ b/ui/src/generated-types.ts
@@ -44,6 +44,7 @@ export interface ConversationStateForTS {
   conversation_id: string;
   working: boolean;
   model?: string;
+  plan_mode?: boolean;
 }
 
 export interface NotificationEventForTS {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2032,6 +2032,36 @@ button {
 }
 
 /* Message Input */
+.message-input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0;
+  width: 100%;
+}
+
+.message-input-row .message-input-container {
+  flex: 1;
+  min-width: 0;
+}
+
+.plan-mode-toggle {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  align-self: flex-end;
+  margin-bottom: 14px;
+}
+
+.plan-mode-toggle:hover {
+  color: var(--text-primary);
+}
+
 .message-input-container {
   flex: 0 0 auto;
   background: var(--bg-base);


### PR DESCRIPTION
This PR to addresses some of the issues I was having with Shelley. Mostly that it felt kind of slow and muddlesome having to wait a long time between prompts.

This allows users to keep typing while the agent is working - which is useful for things like adding context, adding stuff you forgot, making clarifications, or redirecting it if it's making mistakes. Similarly calls to subagents don't block anymore. It advises the agent to use `wait: false` which keeps the conversation going. Subagents notify the parents when they are complete. Overall this gives a livelier feel to the session, where you can pay attention and help steer the ship, rather than it feeling hands-off and black-boxy.

Similarly Plan mode is a convenience for letting the agent know not to run off and implement the first thing it thinks of without running it by the user first and getting approval. Patch tools are disabled in Plan Mode but bash is enabled so the agent can search/plan/analyze.

-------

Plan mode: adds [BUILD MODE] / [PLAN MODE] toggle in the status bar. When enabled, editing tools (patch, output_iframe) are filtered from the tool set and [PLAN MODE] is appended to the system prompt. State persists across loop recreation. SSE broadcasts include plan_mode.

Mid-turn message injection: messages sent while the agent is working are now injected between tool calls via QueueUserMessage instead of being deferred until after the turn ends.

Subagent done notifications: when a wait:false subagent finishes, a summary is injected into the parent's loop so the parent agent knows to check results without polling.

FlexBool: fixes a bug where LLMs send "true"/"false" strings instead of native booleans for tool input fields (bash.SlowOK, subagent.Wait).

Closes #88, closes #73, partially addresses #41.

<img width="1088" height="1114" alt="Screenshot 2026-04-12 at 12 44 23 PM" src="https://github.com/user-attachments/assets/30455434-d88e-4ad1-aec5-cf977bf11362" />
<img width="1075" height="1040" alt="Screenshot 2026-04-12 at 12 44 56 PM" src="https://github.com/user-attachments/assets/ad8749ab-1f8f-439a-a518-21cb5b2dcc06" />
