### PR TITLE
add mid-turn message injection and subagent done notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,5 @@
       reads the `action` field from the input and dispatches to the right sub-component)
     - `loop/predictable.go` (the "tool smorgasbord" demo response)
     - See `ui/src/components/AGENTS.md` for more detail.
+
+16. Prefer `wait: false` for subagents doing background research. Use `wait: true` only when you need the result to continue, and keep timeouts short (30s max). Never block the conversation for minutes.

--- a/server/convo.go
+++ b/server/convo.go
@@ -69,6 +69,10 @@ type ConversationManager struct {
 	// onStateChange is called when the conversation state changes.
 	// This allows the server to broadcast state changes to all subscribers.
 	onStateChange func(state ConversationState)
+
+	// onDone is called when the agent finishes working (transitions to not working).
+	// Used by subagents to notify their parent conversation.
+	onDone func()
 }
 
 // NewConversationManager constructs a manager with dependencies but defers hydration until needed.
@@ -100,6 +104,7 @@ func (cm *ConversationManager) SetAgentWorking(working bool) {
 	}
 	cm.agentWorking = working
 	onStateChange := cm.onStateChange
+	onDone := cm.onDone
 	convID := cm.conversationID
 	modelID := cm.modelID
 	cm.mu.Unlock()
@@ -111,6 +116,9 @@ func (cm *ConversationManager) SetAgentWorking(working bool) {
 			Working:        working,
 			Model:          modelID,
 		})
+	}
+	if !working && onDone != nil {
+		onDone()
 	}
 }
 
@@ -281,13 +289,14 @@ func (cm *ConversationManager) AcceptUserMessage(ctx context.Context, service ll
 	return isFirst, nil
 }
 
-// QueueMessage records a user message to the database as "queued" and holds it
-// for delivery after the current agent turn (or distillation) completes.
-// The message is visible in the UI immediately (with queued status).
+// QueueMessage records a user message to the database and, when the agent
+// is actively working, injects it into the loop's message queue so it gets
+// picked up between tool calls — not after the entire turn ends.
+// During distillation or when no loop exists, messages are held for later.
 func (cm *ConversationManager) QueueMessage(ctx context.Context, s *Server, modelID string, message llm.Message) error {
 	// Record to DB with queued user_data so it appears in the UI.
 	// Mark as excluded_from_context so ensureLoop won't load it into
-	// the loop's history — we'll feed it via QueueUserMessage when draining.
+	// the loop's history — we feed it via QueueUserMessage directly.
 	userData := map[string]interface{}{"queued": true}
 	createdMsg, err := s.db.CreateMessage(ctx, db.CreateMessageParams{
 		ConversationID:      cm.conversationID,
@@ -312,25 +321,59 @@ func (cm *ConversationManager) QueueMessage(ctx context.Context, s *Server, mode
 	go s.notifySubscribersNewMessage(context.WithoutCancel(ctx), cm.conversationID, createdMsg)
 
 	cm.mu.Lock()
-	cm.pendingMessages = append(cm.pendingMessages, pendingMessage{
-		Message:   message,
-		ModelID:   modelID,
-		MessageID: createdMsg.MessageID,
-	})
+	loopInstance := cm.loop
+	distilling := cm.distilling
 	cm.lastActivity = time.Now()
-	// If the agent is no longer working (and not distilling), drain immediately.
-	// This handles the race where drainPendingMessages ran (finding nothing)
-	// before this QueueMessage call appended the message.
-	// During distillation, messages must wait — the distill goroutine will drain.
-	needsDrain := !cm.agentWorking && !cm.distilling
 	cm.mu.Unlock()
 
-	cm.logger.Info("Queued user message", "message_id", createdMsg.MessageID)
+	msgID := createdMsg.MessageID
 
-	if needsDrain {
-		cm.logger.Info("Agent not working, draining immediately")
-		go cm.drainPendingMessages(s)
+	// If distilling or no loop, defer until later.
+	if distilling || loopInstance == nil {
+		cm.mu.Lock()
+		cm.pendingMessages = append(cm.pendingMessages, pendingMessage{
+			Message:   message,
+			ModelID:   modelID,
+			MessageID: msgID,
+		})
+		needsDrain := !cm.agentWorking && !cm.distilling
+		cm.mu.Unlock()
+
+		cm.logger.Info("Queued user message (deferred)", "message_id", msgID)
+
+		if needsDrain {
+			cm.logger.Info("Agent not working, draining immediately")
+			go cm.drainPendingMessages(s)
+		}
+		return nil
 	}
+
+	// Inject directly into the loop so it's picked up between tool calls.
+	loopInstance.QueueUserMessage(message)
+	cm.logger.Info("Injected user message into active loop", "message_id", msgID)
+
+	// Clear the queued/excluded flags so the message is visible in context.
+	go func() {
+		bgCtx := context.Background()
+		if err := s.db.QueriesTx(bgCtx, func(q *generated.Queries) error {
+			if err := q.UpdateMessageExcludedFromContext(bgCtx, generated.UpdateMessageExcludedFromContextParams{
+				ExcludedFromContext: false,
+				MessageID:           msgID,
+			}); err != nil {
+				return err
+			}
+			newData := `{}`
+			return q.UpdateMessageUserData(bgCtx, generated.UpdateMessageUserDataParams{
+				UserData:  &newData,
+				MessageID: msgID,
+			})
+		}); err != nil {
+			cm.logger.Error("Failed to clear queued flags", "message_id", msgID, "error", err)
+		}
+		if updatedMsg, err := s.db.GetMessageByID(bgCtx, msgID); err == nil {
+			s.broadcastMessageUpdate(bgCtx, cm.conversationID, updatedMsg)
+		}
+	}()
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -746,6 +746,11 @@ func (s *Server) getOrCreateSubagentConversationManager(ctx context.Context, con
 			return nil, err
 		}
 
+		// Wire up done notification: when this subagent finishes, notify the parent.
+		manager.onDone = func() {
+			go s.notifyParentSubagentDone(conversationID)
+		}
+
 		s.activeConversations[conversationID] = manager
 		return manager, nil
 	})
@@ -753,6 +758,66 @@ func (s *Server) getOrCreateSubagentConversationManager(ctx context.Context, con
 		return nil, err
 	}
 	return manager, nil
+}
+
+// notifyParentSubagentDone injects a message into the parent conversation's loop
+// when a subagent finishes, so the parent agent knows to check results.
+func (s *Server) notifyParentSubagentDone(subagentConversationID string) {
+	ctx := context.Background()
+
+	// Look up the subagent's parent conversation ID and slug
+	var conv generated.Conversation
+	err := s.db.Queries(ctx, func(q *generated.Queries) error {
+		var err error
+		conv, err = q.GetConversation(ctx, subagentConversationID)
+		return err
+	})
+	if err != nil || conv.ParentConversationID == nil {
+		return
+	}
+
+	parentID := *conv.ParentConversationID
+	slug := "unknown"
+	if conv.Slug != nil {
+		slug = *conv.Slug
+	}
+
+	// Find the parent's loop and inject a notification
+	s.mu.Lock()
+	parentManager, ok := s.activeConversations[parentID]
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	parentManager.mu.Lock()
+	loopInstance := parentManager.loop
+	parentManager.mu.Unlock()
+	if loopInstance == nil {
+		return
+	}
+
+	// Get the subagent's last response for the notification
+	runner := NewSubagentRunner(s)
+	response, err := runner.getLastAssistantResponse(ctx, subagentConversationID)
+	if err != nil || response == "" {
+		response = "(completed, use subagent tool to read results)"
+	}
+	// Truncate long responses
+	if len(response) > 500 {
+		response = response[:500] + "..."
+	}
+
+	notification := llm.Message{
+		Role: llm.MessageRoleUser,
+		Content: []llm.Content{{
+			Type: llm.ContentTypeText,
+			Text: fmt.Sprintf("[Subagent '%s' finished]\n%s", slug, response),
+		}},
+	}
+
+	loopInstance.QueueUserMessage(notification)
+	s.logger.Info("Notified parent of subagent completion", "subagent", slug, "parent", parentID)
 }
 
 // ExtractDisplayData extracts display data from message content for storage


### PR DESCRIPTION
- send messages to agent while it's working (injected between tool calls)
- parent conversation notified with summary when subagent finishes
- always use wait:false for subagents (system prompt guideline)
-------

## Mid-turn message injection and subagent done notifications

### The problem

When the agent is working (executing tool calls), user messages are queued and only delivered after the entire turn ends. This means:

1. **You can't course-correct mid-task.** If you realize you forgot to mention something, or want to change direction, your message sits in a queue until the agent finishes its current chain of tool calls — which can be minutes. By then it may have gone down the wrong path.

2. **Subagents force a bad choice: block or forget.** With `wait: true` (the default), the parent sits there stuck until the subagent finishes — serial execution, no parallelism. With `wait: false`, the parent keeps working, but it never finds out the subagent finished. The results just sit there until the user manually prompts "check on that subagent." Neither option is good: you either waste time blocking, or you waste time chasing down results.

Shelley *is* async — messages get queued and the UI shows them immediately. But the agent doesn't actually *see* them until its turn is over. It's async from the user's perspective but synchronous from the agent's.

### What this changes

**Mid-turn injection:** When the user sends a message while the agent is working, instead of appending to `pendingMessages` for post-turn draining, we inject directly into the loop's `messageQueue` via `QueueUserMessage`. The loop already checks this queue between tool calls (in `executeToolCalls`), so the message gets picked up at the next natural pause — between two tool executions, not after the entire turn. The DB flags (excluded_from_context, queued user_data) are cleared asynchronously so the message appears normally in history.

The fallback path is preserved: if the loop doesn't exist yet or distillation is running, messages still queue the old way.

**Subagent done notifications:** When a subagent's `agentWorking` transitions to `false`, an `onDone` callback fires. This looks up the parent conversation, grabs the subagent's last assistant response (truncated to 500 chars), and injects a `[Subagent 'slug' finished]\n<summary>` user message into the parent's loop. The parent sees it immediately — between tool calls — and can act on the results, catch errors, or adjust its plan without waiting for its own turn to end and without the user having to prompt it.

Done notifications make `wait: false` actually usable. The parent keeps working while subagents run, *and* gets notified with a summary when each one finishes — so it can react, catch errors, and incorporate results within the same turn. No blocking, no forgetting.

### What it feels like

Before: "I'll type this correction... ok it's queued... waiting... waiting... ok the agent finished, now it's reading my message, now it's redoing work."

And for subagents: you either block with `wait: true` and watch the parent do nothing for minutes, or use `wait: false` and then spend time prompting "go check on that subagent" and discovering one of them went sideways after the fact.

After: The agent reads your message within seconds (at the next tool boundary) and adjusts course. Subagent results flow into the parent automatically — the parent reacts to a subagent finishing, checks if the output makes sense, and incorporates it into its work, all within the same turn.

### Changes

- `server/convo.go`: `QueueMessage` rewritten to inject into active loop when available; `onDone` callback field added to `ConversationManager`
- `server/server.go`: `notifyParentSubagentDone` method; `onDone` wired in `getOrCreateSubagentConversationManager`
- `AGENTS.md`: guideline about preferring `wait: false` for subagents

### What it doesn't change

- `loop.go` is untouched — `QueueUserMessage` and the between-tool-calls check already existed
- `drainPendingMessages` is untouched — still used for the distillation/no-loop fallback
- No UI changes, no DB migrations, no new tools

### How to test

**Mid-turn injection:**
1. Start a conversation and ask the agent to do something that takes a while (e.g. "read every file in this directory and summarize each one")
2. While it's working (you'll see "Agent working..."), type a follow-up message like "also ignore any test files"
3. The message should be picked up between tool calls — the agent adjusts its behavior within seconds, not after the full turn ends

**Subagent done notifications:**
1. Ask the agent to spawn subagents with `wait: false` — e.g. "launch two subagents: one to count the Go files in this repo, one to count the TypeScript files"
2. Watch the parent keep working after spawning them
3. When each subagent finishes, a `[Subagent 'slug' finished]` message appears in the parent's conversation with a summary of the result
4. The parent reacts to the notification and incorporates the results — no manual "go check on that subagent" prompting needed

**Predictable model (no API key needed):**
1. Build and run with `--predictable-only`
2. Mid-turn injection can be verified by sending a message while a predictable conversation is "working" — check server logs for `Injected user message into active loop`
3. Subagent notifications can be verified by watching logs for `Notified parent of subagent completion`