### PR TITLE
ui: system sans font, inline code rendering, message styling

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,html}'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx,json,css,html}'",
-    "test": "tsx src/utils/linkify.test.runner.ts && tsx src/components/MarkdownContent.test.ts && tsx src/services/conversationCache.test.runner.ts && tsx src/utils/ansi.test.ts",
+    "test": "tsx src/utils/linkify.test.runner.ts && tsx src/utils/inlineText.test.runner.ts && tsx src/components/MarkdownContent.test.ts && tsx src/services/conversationCache.test.runner.ts && tsx src/utils/ansi.test.ts",
     "generate-types": "cd .. && go run ./cmd/go2ts.go -o ui/src/generated-types.ts",
     "test:e2e": "pnpm run build && playwright test",
     "test:e2e:headed": "pnpm run build && playwright test --headed",

--- a/ui/src/components/Message.tsx
+++ b/ui/src/components/Message.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { linkifyText } from "../utils/linkify";
+import { renderInlineText } from "../utils/inlineText";
 import { useMarkdown } from "../contexts/MarkdownContext";
 import MarkdownContent from "./MarkdownContent";
 import {
@@ -498,7 +498,9 @@ const Message = React.memo(function Message({
           return <MarkdownContent text={content.Text || ""} />;
         }
         return (
-          <div className="whitespace-pre-wrap break-words">{linkifyText(content.Text || "")}</div>
+          <div className="whitespace-pre-wrap break-words">
+            {renderInlineText(content.Text || "")}
+          </div>
         );
       case "tool_use":
         // IMPORTANT: When adding a new tool component here, also add it to:

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -13,8 +13,7 @@ body {
   margin: 0;
   height: 100%;
   overflow: hidden;
-  font-family:
-    "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace;
+  font-family: var(--font-sans);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   letter-spacing: -0.01em;
@@ -24,6 +23,9 @@ body {
 
 /* CSS Variables */
 :root {
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, Roboto,
+    "Helvetica Neue", Arial, sans-serif;
   --font-mono:
     "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace;
   --primary: #2563eb;
@@ -33,6 +35,8 @@ body {
   --bg-tertiary: #f3f4f6;
   --bg-hover: #f3f4f6;
   --border: #e5e7eb;
+  --code-bg: #eceef2;
+  --user-bubble-bg: #ffffff;
   --text-primary: #111827;
   --text-secondary: #6b7280;
   --text-tertiary: #9ca3af;
@@ -70,6 +74,8 @@ body {
   --bg-tertiary: #374151;
   --bg-hover: #374151;
   --border: #374151;
+  --code-bg: #414a59;
+  --user-bubble-bg: #1f2937;
   --text-primary: #f9fafb;
   --text-secondary: #9ca3af;
   --text-tertiary: #6b7280;
@@ -416,13 +422,14 @@ button {
 }
 
 .header-title {
+  font-family: var(--font-mono);
   font-size: 1rem;
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   letter-spacing: -0.02em;
-  min-width: 0; /* Allow shrinking */
+  min-width: 0;
 }
 
 .header-actions {
@@ -582,7 +589,6 @@ button {
 }
 
 .conversation-group-label {
-  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -726,12 +732,17 @@ button {
   overflow-wrap: break-word;
   word-wrap: break-word;
   min-width: 0;
+  font-size: 0.9375rem;
 }
 
 .message-user .message-content {
   margin-left: auto;
   max-width: 80%;
-  color: var(--user-message-text);
+  background: var(--user-bubble-bg);
+  color: var(--text-primary);
+  font-weight: 500;
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
 .message-agent .message-content,
@@ -1051,7 +1062,7 @@ button {
 .subagent-model-badge {
   background: var(--bg-tertiary);
   color: var(--text-tertiary);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   font-size: 0.65rem;
 }
 
@@ -2464,7 +2475,6 @@ button {
 }
 
 .message-input-container.shell-mode .message-textarea {
-  font-family: var(--font-mono);
   background: transparent;
   padding-left: 36px;
   width: 100%;
@@ -2696,10 +2706,11 @@ select:disabled {
 
 .animated-working {
   display: inline;
+  font-family: var(--font-mono);
 }
 
 .animated-working .bold-letter {
-  font-weight: 600;
+  color: var(--text-primary);
 }
 
 .status-button {
@@ -3220,6 +3231,7 @@ svg {
   height: 100%;
 }
 
+
 /* Status bar configuration controls for empty conversations */
 .status-bar-config {
   display: flex;
@@ -3295,7 +3307,6 @@ svg {
   background: var(--bg-tertiary);
   color: var(--text-primary);
   font-size: 0.75rem;
-  font-family: var(--font-mono);
   cursor: pointer;
   transition: all 0.2s;
   white-space: normal; /* Allow text to wrap */
@@ -3612,7 +3623,6 @@ svg {
   background: var(--bg-base);
   color: var(--text-primary);
   font-size: 0.75rem;
-  font-family: var(--font-mono);
   cursor: pointer;
   appearance: auto;
 }
@@ -3633,7 +3643,6 @@ svg {
   background: var(--bg-base);
   color: var(--text-primary);
   font-size: 0.75rem;
-  font-family: var(--font-mono);
   cursor: pointer;
   transition: border-color 0.2s;
   width: 100%;
@@ -3673,7 +3682,6 @@ svg {
   background: var(--bg-tertiary);
   color: var(--text-primary);
   font-size: 0.75rem;
-  font-family: var(--font-mono);
   cursor: pointer;
   transition: all 0.2s;
   width: 100%;
@@ -3748,7 +3756,6 @@ svg {
   background: transparent;
   color: var(--text-primary);
   font-size: 0.875rem;
-  font-family: var(--font-mono);
   cursor: pointer;
   text-align: left;
   transition: background 0.15s;
@@ -3827,7 +3834,6 @@ svg {
   background: var(--bg-base);
   color: var(--text-primary);
   font-size: 0.75rem;
-  font-family: var(--font-mono);
   transition: border-color 0.2s;
   width: 100%;
   box-sizing: border-box;
@@ -6653,7 +6659,7 @@ kbd {
 .markdown-content code {
   font-family: var(--font-mono);
   font-size: 0.875rem;
-  background: var(--bg-tertiary);
+  background: var(--code-bg);
   padding: 0.15em 0.35em;
   border-radius: 4px;
 }
@@ -6661,7 +6667,7 @@ kbd {
 .markdown-content pre {
   margin: 0.75em 0;
   padding: 0.75em 1em;
-  background: var(--bg-tertiary);
+  background: var(--code-bg);
   border-radius: 6px;
   overflow-x: auto;
 }
@@ -6670,6 +6676,30 @@ kbd {
   background: none;
   padding: 0;
   font-size: 0.875rem;
+}
+
+.inline-code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--code-bg);
+  padding: 0.15em 0.35em;
+  border-radius: 4px;
+}
+
+.inline-code-block {
+  margin: 0.5em 0;
+  padding: 0.75em 1em;
+  background: var(--code-bg);
+  border-radius: 6px;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.inline-code-block code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: none;
+  padding: 0;
 }
 
 .markdown-content blockquote {
@@ -7157,7 +7187,7 @@ kbd {
 }
 
 .msg-worktree {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 0.75rem;
   margin-right: 0.5em;
 }
@@ -7168,7 +7198,7 @@ kbd {
 }
 
 .msg-commit-hash {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 0.75rem;
   background: var(--bg-tertiary);
   padding: 0.1em 0.3em;
@@ -7230,7 +7260,6 @@ kbd {
 
 .msg-unexpected-role-text {
   color: var(--warning-text);
-  font-family: var(--font-mono);
 }
 
 .msg-unexpected-content {
@@ -7246,7 +7275,6 @@ kbd {
 
 .msg-unknown-content-label {
   margin-bottom: 0.5rem;
-  font-family: monospace;
 }
 
 .msg-media-section {
@@ -7614,7 +7642,7 @@ kbd {
 }
 
 .drawer-git-hash {
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   cursor: pointer;
 }
 
@@ -7868,7 +7896,7 @@ kbd {
 }
 
 .hf-row-git-hash {
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   flex-shrink: 0;
 }
 
@@ -8131,7 +8159,7 @@ kbd {
 .model-bar-name {
   color: var(--text-secondary);
   font-size: 0.875rem;
-  font-family: monospace;
+  font-family: var(--font-mono);
 }
 
 /* Floating toolbar shown above/below a text selection inside a commentable

--- a/ui/src/utils/inlineText.test.runner.ts
+++ b/ui/src/utils/inlineText.test.runner.ts
@@ -1,0 +1,17 @@
+import { runTests } from "./inlineText.test";
+
+const { passed, failed, failures } = runTests();
+
+console.log(`\nInlineText Tests: ${passed} passed, ${failed} failed\n`);
+
+if (failures.length > 0) {
+  console.log("Failures:");
+  for (const f of failures) {
+    console.log(f);
+    console.log("");
+  }
+  process.exit(1);
+}
+
+console.log("All tests passed!");
+process.exit(0);

--- a/ui/src/utils/inlineText.test.ts
+++ b/ui/src/utils/inlineText.test.ts
@@ -1,0 +1,122 @@
+import { parseInlineSegments, type InlineSegment } from "./inlineText";
+
+interface TestCase {
+  name: string;
+  input: string;
+  expected: InlineSegment[];
+}
+
+const testCases: TestCase[] = [
+  {
+    name: "plain text",
+    input: "Hello world",
+    expected: [{ type: "text", content: "Hello world" }],
+  },
+  {
+    name: "single inline code",
+    input: "press `Enter` now",
+    expected: [
+      { type: "text", content: "press " },
+      { type: "code", content: "Enter" },
+      { type: "text", content: " now" },
+    ],
+  },
+  {
+    name: "multiple inline codes on one line",
+    input: "use `foo` and `bar`",
+    expected: [
+      { type: "text", content: "use " },
+      { type: "code", content: "foo" },
+      { type: "text", content: " and " },
+      { type: "code", content: "bar" },
+    ],
+  },
+  {
+    name: "fenced code block",
+    input: "before\n```\nline1\nline2\n```\nafter",
+    expected: [
+      { type: "text", content: "before\n" },
+      { type: "codeblock", content: "line1\nline2" },
+      { type: "text", content: "\nafter" },
+    ],
+  },
+  {
+    name: "fenced block with language hint",
+    input: "```js\nconsole.log(1)\n```",
+    expected: [{ type: "codeblock", content: "console.log(1)" }],
+  },
+  {
+    name: "fenced block inline on one line",
+    input: "```code```",
+    expected: [{ type: "codeblock", content: "code" }],
+  },
+  {
+    name: "unclosed single backtick is literal",
+    input: "a `b c",
+    expected: [{ type: "text", content: "a `b c" }],
+  },
+  {
+    name: "empty inline code is literal",
+    input: "a `` b",
+    expected: [{ type: "text", content: "a `` b" }],
+  },
+  {
+    name: "inline code does not cross newlines",
+    input: "a `b\nc` d",
+    expected: [{ type: "text", content: "a `b\nc` d" }],
+  },
+  {
+    name: "mixed inline and block",
+    input: "use `foo`\n```\nblock\n```\nthen `bar`",
+    expected: [
+      { type: "text", content: "use " },
+      { type: "code", content: "foo" },
+      { type: "text", content: "\n" },
+      { type: "codeblock", content: "block" },
+      { type: "text", content: "\nthen " },
+      { type: "code", content: "bar" },
+    ],
+  },
+  {
+    name: "backticks only text unchanged",
+    input: "no code here",
+    expected: [{ type: "text", content: "no code here" }],
+  },
+];
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (Array.isArray(a) || Array.isArray(b)) return false;
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao);
+  const bk = Object.keys(bo);
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) => deepEqual(ao[k], bo[k]));
+}
+
+export function runTests(): { passed: number; failed: number; failures: string[] } {
+  let passed = 0;
+  let failed = 0;
+  const failures: string[] = [];
+  for (const tc of testCases) {
+    const result = parseInlineSegments(tc.input);
+    if (deepEqual(result, tc.expected)) {
+      passed++;
+    } else {
+      failed++;
+      failures.push(
+        `FAIL: ${tc.name}\n  Input: ${JSON.stringify(tc.input)}\n  Expected: ${JSON.stringify(tc.expected)}\n  Got: ${JSON.stringify(result)}`,
+      );
+    }
+  }
+  return { passed, failed, failures };
+}
+
+export { testCases };

--- a/ui/src/utils/inlineText.tsx
+++ b/ui/src/utils/inlineText.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { parseLinks } from "./linkify";
+
+export type InlineSegment =
+  | { type: "text"; content: string }
+  | { type: "code"; content: string }
+  | { type: "codeblock"; content: string };
+
+const FENCE = /```([\s\S]*?)```/g;
+const INLINE_CODE = /`([^`\n]+)`/g;
+
+/**
+ * Parse text into fenced code blocks, inline code spans, and plain text.
+ * Fenced blocks take precedence over inline code. Order is preserved.
+ * If a fenced block's first line has no whitespace, it is treated as a
+ * language hint and stripped (e.g. "```js\ncode\n```" -> "code\n").
+ */
+export function parseInlineSegments(text: string): InlineSegment[] {
+  const out: InlineSegment[] = [];
+  let last = 0;
+  FENCE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = FENCE.exec(text)) !== null) {
+    if (m.index > last) {
+      splitInline(text.slice(last, m.index), out);
+    }
+    let body = m[1];
+    // Strip an optional language hint: a first line containing no whitespace,
+    // followed by a newline. `"js\ncode"` -> `"code"`. `"code"` -> `"code"`.
+    const nl = body.indexOf("\n");
+    if (nl > 0 && !/\s/.test(body.slice(0, nl))) {
+      body = body.slice(nl + 1);
+    }
+    // Strip a single leading newline when the fence opened on its own line.
+    if (body.startsWith("\n")) body = body.slice(1);
+    // Strip a single trailing newline before the closing fence.
+    if (body.endsWith("\n")) body = body.slice(0, -1);
+    out.push({ type: "codeblock", content: body });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) {
+    splitInline(text.slice(last), out);
+  }
+  return out;
+}
+
+function splitInline(text: string, out: InlineSegment[]): void {
+  let last = 0;
+  INLINE_CODE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = INLINE_CODE.exec(text)) !== null) {
+    if (m.index > last) {
+      out.push({ type: "text", content: text.slice(last, m.index) });
+    }
+    out.push({ type: "code", content: m[1] });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) {
+    out.push({ type: "text", content: text.slice(last) });
+  }
+}
+
+/**
+ * Render user-typed text with Slack-style backtick formatting.
+ * - ```fenced``` -> <pre><code>
+ * - `inline`    -> <code>
+ * - URLs in plain-text segments become clickable <a>.
+ * - URLs inside code are NOT linkified.
+ */
+export function renderInlineText(text: string): React.ReactNode {
+  const segments = parseInlineSegments(text);
+  return segments.map((seg, i) => {
+    if (seg.type === "codeblock") {
+      return (
+        <pre key={i} className="inline-code-block">
+          <code>{seg.content}</code>
+        </pre>
+      );
+    }
+    if (seg.type === "code") {
+      return (
+        <code key={i} className="inline-code">
+          {seg.content}
+        </code>
+      );
+    }
+    return <React.Fragment key={i}>{linkifyPlain(seg.content)}</React.Fragment>;
+  });
+}
+
+function linkifyPlain(text: string): React.ReactNode {
+  const parts = parseLinks(text);
+  if (parts.length === 0) return text;
+  if (parts.length === 1 && parts[0].type === "text") return text;
+  return parts.map((p, i) => {
+    if (p.type === "link") {
+      return (
+        <a
+          key={i}
+          href={p.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-link"
+        >
+          {p.content}
+        </a>
+      );
+    }
+    return <React.Fragment key={i}>{p.content}</React.Fragment>;
+  });
+}

--- a/ui/src/utils/linkify.ts
+++ b/ui/src/utils/linkify.ts
@@ -1,5 +1,3 @@
-import React from "react";
-
 // Regex for matching URLs. Only matches http:// and https:// URLs.
 // Avoids matching trailing punctuation that's likely not part of the URL.
 // eslint-disable-next-line no-useless-escape
@@ -54,37 +52,3 @@ export function parseLinks(text: string): LinkifyResult[] {
   return results;
 }
 
-/**
- * Convert text containing URLs into React elements with clickable links.
- * URLs are rendered as <a> tags that open in new tabs.
- * Text is HTML-escaped by React's default behavior.
- */
-export function linkifyText(text: string): React.ReactNode {
-  const segments = parseLinks(text);
-
-  if (segments.length === 0) {
-    return text;
-  }
-
-  // If there's only one text segment with no links, return plain text
-  if (segments.length === 1 && segments[0].type === "text") {
-    return text;
-  }
-
-  return segments.map((segment, index) => {
-    if (segment.type === "link") {
-      return (
-        <a
-          key={index}
-          href={segment.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-link"
-        >
-          {segment.content}
-        </a>
-      );
-    }
-    return <React.Fragment key={index}>{segment.content}</React.Fragment>;
-  });
-}


### PR DESCRIPTION
- Add --font-sans system stack; flip body default from mono to sans
- Keep --font-mono for code, tool I/O, diffs, terminal, header title
- New inlineText.tsx: Slack-style backtick rendering in user messages
- Message body at 15px with white user bubble, border, and shadow
- --code-bg token for distinct code chip backgrounds
- Animated working indicator uses color pulse instead of weight pulse
- Subagent progress bar aligned right with margin-left: auto
- Rename linkify.tsx -> linkify.ts (no JSX left)

------

## UI: system sans font, inline code rendering, message styling

### The problem

Shelley's UI uses a monospace font for everything — conversation text, labels, buttons, dropdowns, status chips. Monospace is right for code and tool output, but for conversational text it reads dense and fatiguing. The interface feels like a terminal pretending to be a chat app.

User messages also render backtick-wrapped text as plain text. If you type `` `foo.go` `` or a fenced code block, it shows up as literal backtick characters instead of styled code spans. This is jarring when every other chat tool (Slack, Discord, GitHub) renders inline code.

### What this changes

**Font stack:** Body default switches from monospace to a system sans-serif stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, ...`). Monospace is preserved where it belongs: code blocks, tool I/O, diffs, file paths, commit hashes, terminal output, the header title, the working indicator, and the plan/build mode badge.

**Inline code rendering:** New `inlineText.tsx` parser handles user message text. Fenced code blocks (`` ```...``` ``), inline code spans (`` `...` ``), and URLs are all rendered properly. Fenced blocks get priority; URLs inside code are not linkified. Agent messages continue to use full markdown rendering.

**Message styling:**
- Message body font size set to 15px (was inheriting 16px browser default — felt oversized relative to the rest of the UI density)
- User messages get a white bubble (`--user-bubble-bg`) with a subtle border and drop shadow, replacing the old blue-text-on-background style (which is visually confusing with what I expect to be hyperlinks)
- New `--code-bg` token (`#eceef2` light / `#414a59` dark) gives code spans a distinct background that doesn't blend into the page

**Minor tweaks:**
- Header title kept in mono 
- Working indicator uses a color pulse instead of a font-weight pulse (eliminates text reflow as letters cycle)
- Stray `font-family: monospace` literals normalized to `var(--font-mono)`
- Mono removed from UI chrome that shouldn't have it: conversation group labels, status chips, select dropdowns, model picker options, config inputs

### Changes

- `ui/src/styles.css`: font stack, variables, message styling, code backgrounds, mono cleanup
- `ui/src/components/Message.tsx`: user text uses `renderInlineText` instead of `linkifyText`
- `ui/src/utils/inlineText.tsx`: new parser for backtick code spans, fenced blocks, and links
- `ui/src/utils/inlineText.test.ts`: 11 test cases
- `ui/src/utils/linkify.tsx` → `linkify.ts`: renamed (no JSX left after removing `linkifyText`)
- `ui/package.json`: added inline text tests to `pnpm test`

### What it doesn't change

- No Go changes, no DB migrations, no new tools
- Agent messages still render through the full markdown pipeline
- All existing functionality preserved — this is purely visual

### How to test

1. Build and open the UI — the font change is immediately visible
2. Type a message with backticks: `` check `main.go` for errors `` — should render with a styled code chip
3. Type a fenced code block — should render as a code block, not raw backticks
4. Compare user vs agent messages — user bubbles should be white with a border, agent messages unchanged
5. Check dark mode — code backgrounds, user bubbles, and todo panel shadows should all adapt
6. Run `cd ui && pnpm test` — all inline text tests should pass