### PR TITLE
add subagent done notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,5 @@
       reads the `action` field from the input and dispatches to the right sub-component)
     - `loop/predictable.go` (the "tool smorgasbord" demo response)
     - See `ui/src/components/AGENTS.md` for more detail.
+
+16. Prefer `wait: false` for subagents doing background research. Use `wait: true` only when you need the result to continue, and keep timeouts short (30s max). Never block the conversation for minutes.

--- a/server/convo.go
+++ b/server/convo.go
@@ -73,6 +73,10 @@ type ConversationManager struct {
 	// onStateChange is called when the conversation state changes.
 	// This allows the server to broadcast state changes to all subscribers.
 	onStateChange func(state ConversationState)
+
+	// onDone is called when the agent finishes working (transitions to not working).
+	// Used by subagents to notify their parent conversation.
+	onDone func()
 }
 
 // NewConversationManager constructs a manager with dependencies but defers hydration until needed.
@@ -134,6 +138,7 @@ func (cm *ConversationManager) SetAgentWorking(working bool) {
 	}
 	cm.agentWorking = working
 	onStateChange := cm.onStateChange
+	onDone := cm.onDone
 	convID := cm.conversationID
 	modelID := cm.modelID
 	cm.mu.Unlock()
@@ -148,6 +153,9 @@ func (cm *ConversationManager) SetAgentWorking(working bool) {
 			Working:        working,
 			Model:          modelID,
 		})
+	}
+	if !working && onDone != nil {
+		onDone()
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -837,6 +837,11 @@ func (s *Server) getOrCreateSubagentConversationManager(ctx context.Context, con
 			existing.Touch()
 			return existing, nil
 		}
+		// Wire up done notification: when this subagent finishes, notify the parent.
+		manager.onDone = func() {
+			go s.notifyParentSubagentDone(conversationID)
+		}
+
 		s.activeConversations[conversationID] = manager
 		s.mu.Unlock()
 		return manager, nil
@@ -845,6 +850,66 @@ func (s *Server) getOrCreateSubagentConversationManager(ctx context.Context, con
 		return nil, err
 	}
 	return manager, nil
+}
+
+// notifyParentSubagentDone injects a message into the parent conversation's loop
+// when a subagent finishes, so the parent agent knows to check results.
+func (s *Server) notifyParentSubagentDone(subagentConversationID string) {
+	ctx := context.Background()
+
+	// Look up the subagent's parent conversation ID and slug
+	var conv generated.Conversation
+	err := s.db.Queries(ctx, func(q *generated.Queries) error {
+		var err error
+		conv, err = q.GetConversation(ctx, subagentConversationID)
+		return err
+	})
+	if err != nil || conv.ParentConversationID == nil {
+		return
+	}
+
+	parentID := *conv.ParentConversationID
+	slug := "unknown"
+	if conv.Slug != nil {
+		slug = *conv.Slug
+	}
+
+	// Find the parent's loop and inject a notification
+	s.mu.Lock()
+	parentManager, ok := s.activeConversations[parentID]
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	parentManager.mu.Lock()
+	loopInstance := parentManager.loop
+	parentManager.mu.Unlock()
+	if loopInstance == nil {
+		return
+	}
+
+	// Get the subagent's last response for the notification
+	runner := NewSubagentRunner(s)
+	response, err := runner.getLastAssistantResponse(ctx, subagentConversationID)
+	if err != nil || response == "" {
+		response = "(completed, use subagent tool to read results)"
+	}
+	// Truncate long responses
+	if len(response) > 500 {
+		response = response[:500] + "..."
+	}
+
+	notification := llm.Message{
+		Role: llm.MessageRoleUser,
+		Content: []llm.Content{{
+			Type: llm.ContentTypeText,
+			Text: fmt.Sprintf("[Subagent '%s' finished]\n%s", slug, response),
+		}},
+	}
+
+	loopInstance.QueueUserMessage(notification)
+	s.logger.Info("Notified parent of subagent completion", "subagent", slug, "parent", parentID)
 }
 
 // ExtractDisplayData extracts display data from message content for storage


### PR DESCRIPTION
## Subagent done notifications

### The problem

Subagents force a bad choice: **block or forget.** With `wait: true` (the default), the parent sits there stuck until the subagent finishes — serial execution, no parallelism. With `wait: false`, the parent keeps working, but it never finds out the subagent finished. The results just sit there until the user manually prompts "check on that subagent." Neither option is good: you either waste time blocking, or you waste time chasing down results.

The infrastructure for async is already there — `wait: false` exists, `QueueUserMessage` exists, the loop checks for injected messages between tool calls. But without notifications, async subagents are fire-and-forget. The parent has no way to know when results are ready.

### What this changes

When a subagent's `agentWorking` transitions to `false`, an `onDone` callback fires. This looks up the parent conversation, grabs the subagent's last assistant response (truncated to 500 chars), and injects a `[Subagent 'slug' finished]\n<summary>` user message into the parent's loop. The parent sees it between tool calls and can act on the results, catch errors, or adjust its plan without waiting for its own turn to end and without the user having to prompt it.

Done notifications make `wait: false` actually usable. The parent keeps working while subagents run, and gets notified with a summary when each one finishes — so it can react, catch errors, and incorporate results within the same turn. No blocking, no forgetting. Subagents go from fire-and-wait to genuinely async and interactive: launch, continue working, react when results arrive.

### What it feels like

Before: you either block with `wait: true` and watch the parent do nothing for minutes, or use `wait: false` and then spend time prompting "go check on that subagent" and discovering one of them went sideways after the fact.

After: subagent results flow into the parent automatically — the parent reacts to a subagent finishing, checks if the output makes sense, and incorporates it into its work, all within the same turn.

### Changes

- `server/convo.go`: `onDone` callback field on `ConversationManager`, called from `SetAgentWorking` when transitioning to not-working
- `server/server.go`: `notifyParentSubagentDone` method; `onDone` wired in `getOrCreateSubagentConversationManager`
- `AGENTS.md`: guideline about preferring `wait: false` for subagents

### What it doesn't change

- `loop.go` is untouched — `QueueUserMessage` and the between-tool-calls check already existed
- `drainPendingMessages` is untouched
- No UI changes, no DB migrations, no new tools

### How to test

1. Ask the agent to spawn subagents with `wait: false` — e.g. "launch two subagents: one to count the Go files in this repo, one to count the TypeScript files"
2. Watch the parent keep working after spawning them
3. When each subagent finishes, a `[Subagent 'slug' finished]` message appears in the parent's conversation with a summary of the result
4. The parent reacts to the notification and incorporates the results — no manual "go check on that subagent" prompting needed

**Predictable model (no API key needed):**
1. Build and run with `--predictable-only`
2. Subagent notifications can be verified by watching logs for `Notified parent of subagent completion`