### PR TITLE
prevent oversized images from bricking conversations

### DIFF
--- a/claudetool/browse/browse.go
+++ b/claudetool/browse/browse.go
@@ -597,6 +597,12 @@ func (b *BrowseTools) screenshotRun(ctx context.Context, input screenshotInput) 
 		}
 	}
 
+	// Ensure image is under the API's 5MB base64 limit
+	imageData, format, err = imageutil.EnsureUnderMaxBytes(imageData)
+	if err != nil {
+		return llm.ErrorToolOut(fmt.Errorf("failed to compress screenshot: %w", err))
+	}
+
 	base64Data := base64.StdEncoding.EncodeToString(imageData)
 	mediaType := "image/" + format
 
@@ -915,6 +921,12 @@ func (b *BrowseTools) readImageRun(ctx context.Context, input readImageInput) ll
 		if err != nil {
 			return llm.ErrorToolOut(fmt.Errorf("failed to resize image: %w", err))
 		}
+	}
+
+	// Ensure image is under the API's 5MB base64 limit
+	imageData, format, err = imageutil.EnsureUnderMaxBytes(imageData)
+	if err != nil {
+		return llm.ErrorToolOut(fmt.Errorf("failed to compress image: %w", err))
 	}
 
 	base64Data := base64.StdEncoding.EncodeToString(imageData)

--- a/llm/ant/ant.go
+++ b/llm/ant/ant.go
@@ -348,6 +348,12 @@ func fromLLMContent(c llm.Content) content {
 		for i, tr := range c.ToolResult {
 			// For image content inside a tool_result, we need to map it to "image" type
 			if tr.MediaType != "" && tr.MediaType == "image/jpeg" || tr.MediaType == "image/png" {
+				// Drop images that exceed the API's 5MB base64 limit (e.g. from history)
+				if len(tr.Data) > maxBase64ImageSize {
+					placeholder := "[image omitted: exceeded 5MB API limit]"
+					toolResult[i] = content{Type: "text", Text: &placeholder}
+					continue
+				}
 				// Format as an image for Claude
 				toolResult[i] = content{
 					Type: "image",
@@ -370,9 +376,15 @@ func fromLLMContent(c llm.Content) content {
 	case llm.ContentTypeText:
 		// Images are represented as text with MediaType and Data
 		if c.MediaType != "" {
-			d.Type = "image"
-			d.Source = json.RawMessage(fmt.Sprintf(`{"type":"base64","media_type":"%s","data":"%s"}`,
-				c.MediaType, c.Data))
+			// Drop images that exceed the API's 5MB base64 limit (e.g. from history)
+			if len(c.Data) > maxBase64ImageSize {
+				placeholder := "[image omitted: exceeded 5MB API limit]"
+				d.Text = &placeholder
+			} else {
+				d.Type = "image"
+				d.Source = json.RawMessage(fmt.Sprintf(`{"type":"base64","media_type":"%s","data":"%s"}`,
+					c.MediaType, c.Data))
+			}
 		} else {
 			d.Text = &c.Text
 		}
@@ -412,6 +424,75 @@ func fromLLMToolUse(tu *llm.ToolUse) *toolUse {
 // stripThinkingBlocks returns a copy of the message with thinking and
 // redacted_thinking content blocks removed. Used to strip stale thinking
 // from older assistant turns before sending to the API.
+// maxBase64ImageSize is the Anthropic API limit for base64-encoded image data (5MB).
+const maxBase64ImageSize = 5 * 1024 * 1024
+
+// maxMediaPerRequest is the maximum number of image blocks allowed per API request.
+// The API rejects requests exceeding this limit.
+// Source: Claude CLI constants/apiLimits.ts (API_MAX_MEDIA_PER_REQUEST)
+const maxMediaPerRequest = 100
+
+// isImageContent reports whether a content block is an image.
+func isImageContent(c llm.Content) bool {
+	return c.MediaType != ""
+}
+
+// stripExcessImages removes the oldest image blocks from messages if the total
+// count exceeds maxMediaPerRequest. This mirrors Claude CLI's stripExcessMediaItems.
+func stripExcessImages(messages []llm.Message) []llm.Message {
+	// Count total images
+	total := 0
+	for _, m := range messages {
+		for _, c := range m.Content {
+			if isImageContent(c) {
+				total++
+			}
+			for _, tr := range c.ToolResult {
+				if isImageContent(tr) {
+					total++
+				}
+			}
+		}
+	}
+
+	toRemove := total - maxMediaPerRequest
+	if toRemove <= 0 {
+		return messages
+	}
+
+	result := make([]llm.Message, len(messages))
+	for i, m := range messages {
+		if toRemove <= 0 {
+			result[i] = m
+			continue
+		}
+		var filtered []llm.Content
+		for _, c := range m.Content {
+			// Strip images nested in tool results
+			if len(c.ToolResult) > 0 && toRemove > 0 {
+				var filteredTR []llm.Content
+				for _, tr := range c.ToolResult {
+					if toRemove > 0 && isImageContent(tr) {
+						toRemove--
+						continue
+					}
+					filteredTR = append(filteredTR, tr)
+				}
+				c.ToolResult = filteredTR
+			}
+			// Strip top-level images
+			if toRemove > 0 && isImageContent(c) {
+				toRemove--
+				continue
+			}
+			filtered = append(filtered, c)
+		}
+		result[i] = m
+		result[i].Content = filtered
+	}
+	return result
+}
+
 func stripThinkingBlocks(msg llm.Message) llm.Message {
 	var filtered []llm.Content
 	for _, c := range msg.Content {
@@ -473,21 +554,24 @@ func (s *Service) fromLLMRequest(r *llm.Request) *request {
 	model := cmp.Or(s.Model, DefaultModel)
 	maxTokens := cmp.Or(s.MaxTokens, maxOutputTokens(model))
 
+	// Strip excess image blocks to stay within API limits (oldest first).
+	inputMessages := stripExcessImages(r.Messages)
+
 	// Find the last assistant message index so we can strip thinking blocks
 	// from all earlier assistant messages. The Anthropic API validates thinking
 	// signatures, and they become invalid when the underlying model version
 	// rotates (e.g. "claude-opus-4-6" points to a new version). Only the
 	// most recent assistant turn's thinking blocks need to be preserved.
 	lastAssistantIdx := -1
-	for i := len(r.Messages) - 1; i >= 0; i-- {
-		if r.Messages[i].Role == llm.MessageRoleAssistant {
+	for i := len(inputMessages) - 1; i >= 0; i-- {
+		if inputMessages[i].Role == llm.MessageRoleAssistant {
 			lastAssistantIdx = i
 			break
 		}
 	}
 
 	var messages []message
-	for i, m := range r.Messages {
+	for i, m := range inputMessages {
 		// Strip thinking/redacted_thinking blocks from all assistant messages
 		// except the last one. This avoids "Invalid signature" errors when
 		// the model version has changed since the thinking was generated.
@@ -543,8 +627,10 @@ func (s *Service) fromLLMRequestStrippingAllThinking(r *llm.Request) *request {
 	model := cmp.Or(s.Model, DefaultModel)
 	maxTokens := cmp.Or(s.MaxTokens, maxOutputTokens(model))
 
+	inputMessages := stripExcessImages(r.Messages)
+
 	var messages []message
-	for _, m := range r.Messages {
+	for _, m := range inputMessages {
 		if m.Role == llm.MessageRoleAssistant {
 			m = stripThinkingBlocks(m)
 		}

--- a/llm/imageutil/resize.go
+++ b/llm/imageutil/resize.go
@@ -60,3 +60,88 @@ func ResizeImage(data []byte, maxDimension int) (resized []byte, format string, 
 
 	return buf.Bytes(), format, true, nil
 }
+
+// MaxBase64Size is the Anthropic API limit for base64-encoded image data.
+// Source: Claude CLI constants/apiLimits.ts (API_IMAGE_MAX_BASE64_SIZE)
+const MaxBase64Size = 5 * 1024 * 1024 // 5 MB
+
+// TargetRawSize is the maximum raw image size that stays under the base64 limit.
+// base64 encoding increases size by 4/3, so: raw = base64_limit * 3/4
+// Source: Claude CLI constants/apiLimits.ts (IMAGE_TARGET_RAW_SIZE)
+const TargetRawSize = MaxBase64Size * 3 / 4 // 3.75 MB
+
+// EnsureUnderMaxBytes compresses an image to stay under the Anthropic API's
+// 5MB base64 limit. It follows the same cascade as Claude CLI:
+//  1. If already under limit, return as-is
+//  2. Try JPEG at quality 80, 60, 40, 20
+//  3. Resize to progressively smaller dimensions + JPEG compression
+//  4. Last resort: 400x400 JPEG at quality 20
+func EnsureUnderMaxBytes(data []byte) ([]byte, string, error) {
+	if len(data) <= TargetRawSize {
+		// Detect format from data
+		_, detectedFormat, err := image.DecodeConfig(bytes.NewReader(data))
+		if err != nil {
+			return data, "png", nil // default to png if we can't detect
+		}
+		return data, detectedFormat, nil
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to decode image for compression: %w", err)
+	}
+
+	bounds := img.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+
+	// Try JPEG at progressively lower quality without resizing
+	for _, quality := range []int{80, 60, 40, 20} {
+		var buf bytes.Buffer
+		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: quality}); err != nil {
+			continue
+		}
+		if buf.Len() <= TargetRawSize {
+			return buf.Bytes(), "jpeg", nil
+		}
+	}
+
+	// Resize to progressively smaller dimensions + JPEG compression
+	for _, scale := range []float64{0.75, 0.5, 0.25} {
+		newWidth := int(float64(width) * scale)
+		newHeight := int(float64(height) * scale)
+		if newWidth < 1 {
+			newWidth = 1
+		}
+		if newHeight < 1 {
+			newHeight = 1
+		}
+
+		resized := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
+		draw.BiLinear.Scale(resized, resized.Bounds(), img, bounds, draw.Over, nil)
+
+		var buf bytes.Buffer
+		if err := jpeg.Encode(&buf, resized, &jpeg.Options{Quality: 60}); err != nil {
+			continue
+		}
+		if buf.Len() <= TargetRawSize {
+			return buf.Bytes(), "jpeg", nil
+		}
+	}
+
+	// Last resort: 400x400 JPEG at quality 20
+	newWidth, newHeight := 400, 400
+	if width > height {
+		newHeight = height * 400 / width
+	} else {
+		newWidth = width * 400 / height
+	}
+	resized := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
+	draw.BiLinear.Scale(resized, resized.Bounds(), img, bounds, draw.Over, nil)
+
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, resized, &jpeg.Options{Quality: 20}); err != nil {
+		return nil, "", fmt.Errorf("failed to compress image as last resort: %w", err)
+	}
+	return buf.Bytes(), "jpeg", nil
+}

--- a/llm/imageutil/resize_test.go
+++ b/llm/imageutil/resize_test.go
@@ -150,3 +150,47 @@ func TestResizeImageNoResizeNeeded(t *testing.T) {
 		t.Error("Expected original data when no resize needed")
 	}
 }
+
+func TestEnsureUnderMaxBytes_SmallImage(t *testing.T) {
+	data := createTestPNG(t, 100, 100)
+	result, format, err := EnsureUnderMaxBytes(data)
+	if err != nil {
+		t.Fatalf("EnsureUnderMaxBytes() error = %v", err)
+	}
+	if format != "png" {
+		t.Errorf("format = %v, want png", format)
+	}
+	if !bytes.Equal(result, data) {
+		t.Error("Expected original data for small image")
+	}
+}
+
+func TestEnsureUnderMaxBytes_LargeImage(t *testing.T) {
+	// Create a large JPEG that exceeds TargetRawSize (3.75MB)
+	// Use a large image with random-ish data encoded as high-quality JPEG.
+	img := image.NewNRGBA(image.Rect(0, 0, 5000, 5000))
+	pix := img.Pix
+	for i := 0; i < len(pix); i++ {
+		pix[i] = byte((i * 127) ^ (i >> 3)) // pseudo-random to defeat compression
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 100}); err != nil {
+		t.Fatalf("Failed to create large test image: %v", err)
+	}
+	data := buf.Bytes()
+
+	if len(data) <= TargetRawSize {
+		t.Skipf("Test image too small (%d bytes), need > %d", len(data), TargetRawSize)
+	}
+
+	result, format, err := EnsureUnderMaxBytes(data)
+	if err != nil {
+		t.Fatalf("EnsureUnderMaxBytes() error = %v", err)
+	}
+	if format != "jpeg" {
+		t.Errorf("format = %v, want jpeg (should have been compressed)", format)
+	}
+	if len(result) > TargetRawSize {
+		t.Errorf("result size %d exceeds target %d", len(result), TargetRawSize)
+	}
+}


### PR DESCRIPTION
## Prevent oversized images from bricking conversations

### The problem

A single image that exceeds Anthropic's 5MB base64 limit permanently bricks the conversation. Since the entire conversation history is replayed on every API call (stateless API), the oversized image in history causes every subsequent request to fail with `image exceeds 5 MB maximum`. The session is unrecoverable — even deleting the original file from disk doesn't help because the base64 data is already stored in the conversation history in the database.

<img width="1195" height="708" alt="Screenshot 2026-05-18 at 9 22 35 PM" src="https://github.com/user-attachments/assets/3c1e46fa-6c15-4d0c-9a1e-a3c2131df1e8" />

Additionally, long conversations accumulate screenshots and images in history that get resent every turn, wasting tokens and money even when the LLM has long since processed them.

### What this changes

Three layers of defense, all modeled on Claude CLI's approach (`constants/apiLimits.ts`, `imageResizer.ts`, `stripExcessMediaItems` in `services/api/claude.ts`):

**1. Compress images at read time** (`imageutil.EnsureUnderMaxBytes`, called in `screenshotRun` and `readImageRun`)

Before an image enters conversation history, ensure it's under 3.75MB raw (which becomes ~5MB in base64). Follows Claude CLI's `maybeResizeAndDownsampleImageBuffer` cascade:
- If already under limit, pass through
- Try JPEG at quality 80, 60, 40, 20 (preserving dimensions)
- Resize to 75%, 50%, 25% of original dimensions + JPEG compression
- Last resort: 400×400 JPEG at quality 20

This prevents the bug from ever occurring in new conversations.

**2. Drop oversized images at serialization time** (`fromLLMContent` in `ant.go`)

When building the API request, if any image's base64 data exceeds 5MB, replace it with `[image omitted: exceeded 5MB API limit]`. This **unbricks existing conversations** — the oversized image in history gets replaced with a text placeholder instead of causing a 400 error.

**3. Cap total image count per request** (`stripExcessImages` in `ant.go`)

Before sending to the API, count all image blocks across messages. If the total exceeds 100 (Anthropic's `API_MAX_MEDIA_PER_REQUEST`), strip the oldest images first. This mirrors Claude CLI's `stripExcessMediaItems` and prevents token waste from accumulated screenshots in long conversations.

### Changes

- `llm/imageutil/resize.go`: `EnsureUnderMaxBytes` — compress images to stay under the 5MB base64 API limit
- `llm/imageutil/resize_test.go`: tests for the new function
- `claudetool/browse/browse.go`: call `EnsureUnderMaxBytes` in `screenshotRun` and `readImageRun` before base64 encoding
- `llm/ant/ant.go`: `stripExcessImages` to cap at 100 images per request; `maxBase64ImageSize` check in `fromLLMContent` to drop oversized images from history at serialization time

### What it doesn't change

- No DB migrations, no changes to how images are stored
- No changes to the loop, conversation manager, or message recording
- Non-Anthropic providers (`oai.go`, `gem.go`) are unaffected — the serialization-time checks are in `ant.go` only, and the read-time compression is a reasonable size ceiling for any provider

### How to test

**Prevention:**
1. Take a screenshot of a complex page that would produce a large PNG
2. Verify in logs that the image was compressed if it exceeded 3.75MB

**Unbrick:**
1. Find a conversation with an oversized image in history (one that was returning "image exceeds 5 MB maximum")
2. Send a new message — it should succeed, with the oversized image replaced by `[image omitted: exceeded 5MB API limit]`

**Count cap:**
1. In a long conversation with many screenshots, verify that the API request contains at most 100 image blocks (check with debug logging or request dumps)