### PR TITLE
shelley/ui: don't disable the message input when a draft is lazily created

### DIFF
--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -1280,6 +1280,11 @@ function ChatInterface({
   const loadingProgressDelayRef = useRef<number | null>(null);
   // Track the current conversation ID to detect if user navigated away during async operations
   const currentConversationIdRef = useRef<string | null>(conversationId);
+  // Mirror of lazyDraftId (the state lives with the draft logic below) that the
+  // message-load effect can read without taking lazyDraftId as a dependency.
+  // Written synchronously when a draft is lazily created so the load triggered
+  // by the resulting conversationId flip can be skipped before any effect runs.
+  const lazyDraftIdRef = useRef<string | null>(null);
 
   const handleOpenDiffViewer = useCallback((commit: string, cwd?: string) => {
     setDiffViewerInitialCommit(commit);
@@ -1448,7 +1453,15 @@ function ChatInterface({
     const unsubStore = messageStore.subscribe(focusedId, sync);
     const unsubTransient = messageStore.subscribeTransient(focusedId, syncTransient);
 
-    loadMessages(focusedId);
+    // A draft we just lazily created from this input session has no messages
+    // to load. Skip the load so `loading` never flips on — toggling it would
+    // disable the textarea, which on iOS dismisses the soft keyboard mid-typing
+    // (and the post-load refocus can't reopen it without a user gesture). Live
+    // updates still arrive via the store subscription above; reconnect-driven
+    // reloads still call loadMessages normally.
+    if (focusedId !== lazyDraftIdRef.current) {
+      loadMessages(focusedId);
+    }
 
     return () => {
       unsubStore();
@@ -2937,7 +2950,10 @@ function ChatInterface({
   const [lazyDraftId, setLazyDraftId] = useState<string | null>(null);
   useEffect(() => {
     // Genuine navigation to a different conversation ends the session.
-    if (lazyDraftId && conversationId !== lazyDraftId) setLazyDraftId(null);
+    if (lazyDraftId && conversationId !== lazyDraftId) {
+      setLazyDraftId(null);
+      lazyDraftIdRef.current = null;
+    }
   }, [conversationId, lazyDraftId]);
 
   // Initialize from the conversation row when switching into a draft.
@@ -2991,9 +3007,13 @@ function ChatInterface({
         })
         .then((conv) => {
           draftConvIdRef.current = conv.conversation_id;
-          // Mark this as the current input session's draft so the key flip
-          // below doesn't remount the textarea out from under the caret.
+          // Mark this as the current input session's draft so (a) the key flip
+          // below doesn't remount the textarea out from under the caret and
+          // (b) the message-load effect skips its pointless, keyboard-dismissing
+          // load for it. The ref is set synchronously (before the conversationId
+          // flip's effect runs); the state drives the render-time key.
           setLazyDraftId(conv.conversation_id);
+          lazyDraftIdRef.current = conv.conversation_id;
           onDraftCreated?.(conv.conversation_id);
           return conv.conversation_id;
         });


### PR DESCRIPTION
> Clone https://github.com/boldsoftware/shelley and kickoff a dev server because i need you to diagnose and then fix this bug:
>
> There is a problem where maybe about one second after entering the first character into your input box the screen seems to re-draw or something and the keyboard gets closed so I then have to click the input box again in order to keep typing this occurs on iOS mobile. I'm pretty sure it's tied to the new draft feature

---

<details>
<summary><b>Claude Opus 4.8 commentary</b></summary>

### Root cause

You were right that it's the new draft feature — but **not** a remount (the `key` trick from `52b3b6e` already prevents that). It's the message input getting **`disabled`** for a moment, which on iOS dismisses the soft keyboard.

Causal chain:

1. The first keystroke schedules the 600 ms debounced draft autosave.
2. Autosave `POST`s, the draft is created, and `conversationId` flips `null` → new id.
3. That flip runs the conversation-switch effect (`ChatInterface.tsx`, `useEffect([conversationId])`), which calls `loadMessages(newId)`.
4. The draft has no messages, but `loadMessages` still does `setLoading(true)` while it fetches (`ChatInterface.tsx`, the `if (!cached) setLoading(true)` line).
5. `disabled = sending || loading`, so `<textarea disabled>` toggles on for the duration of the fetch.
6. **On iOS Safari, disabling the focused textarea dismisses the keyboard** and blurs it. The post-load refocus is skipped on mobile (and iOS won't reopen the keyboard without a user gesture anyway) — so you have to tap the box again.

The ~1 s you described ≈ the 600 ms debounce + the draft-create round-trip.

### The fix

A lazily-created draft has **no history to load**, so loading it is both pointless and harmful. Extend the existing `lazyDraftId` "same input session" concept to the load path: track the lazy draft id in a `lazyDraftIdRef` (set synchronously at create time, cleared on navigation) and skip `loadMessages` for it. `loading`/`disabled` never flip, the keyboard stays up, and live updates still flow via the existing store subscription. Reconnect-driven reloads still call `loadMessages` normally.

### Verification

Instrumented the real textarea and measured the `disabled` attribute after the first keystroke:

| Build | `disabled` toggles after 1st char | iOS keyboard |
|---|---|---|
| Before fix | **2** (on→off at ~640 ms) | closes |
| After fix  | **0** | stays open |

- Confirmed on a **real iPhone** (Safari) via a before/after comparison: pre-fix build drops the keyboard, fixed build keeps it.
- Draft autosave still works (draft row created, body persisted, URL updates); continued typing, send → draft promotion, and message rendering all verified; fresh load directly into an existing conversation still loads messages normally (no regression).
- `pnpm type-check`, `pnpm lint`, and all UI unit tests pass.

**Files:** `ui/src/components/ChatInterface.tsx` (+24 / −4)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
