### PR TITLE
Feature/switch model mid conversation

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -999,6 +999,9 @@ func (s *Server) conversationMux() *http.ServeMux {
 	mux.HandleFunc("POST /{id}/switch-model", func(w http.ResponseWriter, r *http.Request) {
 		s.handleSwitchModel(w, r, r.PathValue("id"))
 	})
+	mux.HandleFunc("POST /{id}/thinking-level", func(w http.ResponseWriter, r *http.Request) {
+		s.handleUpdateThinkingLevel(w, r, r.PathValue("id"))
+	})
 	return mux
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -996,6 +996,9 @@ func (s *Server) conversationMux() *http.ServeMux {
 	mux.HandleFunc("POST /{id}/fork", func(w http.ResponseWriter, r *http.Request) {
 		s.handleForkConversation(w, r, r.PathValue("id"))
 	})
+	mux.HandleFunc("POST /{id}/switch-model", func(w http.ResponseWriter, r *http.Request) {
+		s.handleSwitchModel(w, r, r.PathValue("id"))
+	})
 	return mux
 }
 

--- a/server/switch_model.go
+++ b/server/switch_model.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"shelley.exe.dev/db/generated"
+)
+
+// SwitchModelRequest is the body for POST /conversation/<id>/switch-model.
+type SwitchModelRequest struct {
+	Model string `json:"model"`
+}
+
+// handleSwitchModel handles POST /conversation/<id>/switch-model.
+// It switches the model for an existing conversation without starting a new
+// generation. The full conversation history is preserved — only the LLM
+// service changes. This is analogous to what distill-new-generation does when
+// the caller passes a different model, but without summarizing or compacting
+// the history.
+//
+// The handler:
+//  1. Validates the requested model exists.
+//  2. Resets the in-memory conversation loop (stops any in-flight work).
+//  3. Updates the persisted model in the database.
+//  4. Re-hydrates the conversation manager so the next message uses the new model.
+//  5. Broadcasts the change to SSE subscribers so the UI updates.
+func (s *Server) handleSwitchModel(w http.ResponseWriter, r *http.Request, conversationID string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	var req SwitchModelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.Model == "" {
+		http.Error(w, "model is required", http.StatusBadRequest)
+		return
+	}
+
+	// Validate the model exists and we can create a service for it.
+	if _, err := s.llmManager.GetService(req.Model); err != nil {
+		s.logger.Error("Unsupported model for switch", "model", req.Model, "error", err)
+		http.Error(w, fmt.Sprintf("Unsupported model: %s", req.Model), http.StatusBadRequest)
+		return
+	}
+
+	// Check the conversation exists.
+	existing, err := s.db.GetConversationByID(ctx, conversationID)
+	if err != nil {
+		http.Error(w, "Conversation not found", http.StatusNotFound)
+		return
+	}
+
+	// If already using this model, no-op.
+	if existing.Model != nil && *existing.Model == req.Model {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":          "ok",
+			"conversation_id": conversationID,
+			"model":           req.Model,
+			"changed":         false,
+		})
+		return
+	}
+
+	// Get the active conversation manager (if any).
+	s.mu.Lock()
+	manager, hasManager := s.activeConversations[conversationID]
+	s.mu.Unlock()
+
+	if hasManager {
+		// If the agent is currently working, cancel it first. This mirrors
+		// what the cancel handler does before resetting.
+		if manager.IsAgentWorking() {
+			if err := manager.CancelConversation(ctx); err != nil {
+				s.logger.Warn("Failed to cancel active conversation during model switch",
+					"conversationID", conversationID, "error", err)
+				// Non-fatal: ResetLoop will force-stop it anyway.
+			}
+		}
+
+		// Reset the loop. This tears down the in-memory LLM loop, clears
+		// the cached modelID, and forces re-hydration on the next message
+		// — exactly what distillation does.
+		manager.ResetLoop()
+	}
+
+	// Persist the new model.
+	if err := s.db.ForceUpdateConversationModel(ctx, conversationID, req.Model); err != nil {
+		s.logger.Error("Failed to update model", "conversationID", conversationID, "model", req.Model, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Re-fetch conversation to pick up the model change.
+	conversation, err := s.db.GetConversationByID(ctx, conversationID)
+	if err != nil {
+		s.logger.Error("Failed to re-fetch conversation after model switch", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Re-hydrate so the manager is ready for the next message with the new model.
+	if hasManager {
+		if err := manager.Hydrate(ctx); err != nil {
+			s.logger.Error("Failed to hydrate after model switch", "error", err)
+			// Non-fatal: the next AcceptUserMessage will trigger hydration anyway.
+		}
+	}
+
+	// Insert a system-visible note so the user (and the LLM on future turns)
+	// can see that the model changed.
+	s.recordModelSwitchNote(ctx, conversationID, existing, conversation)
+
+	// Broadcast the updated conversation to SSE subscribers.
+	if hasManager {
+		manager.broadcastStream(StreamResponse{Conversation: conversation})
+	}
+	s.publishConversationListUpdate(ConversationListUpdate{Type: "update", Conversation: conversation})
+
+	s.logger.Info("Switched conversation model",
+		"conversationID", conversationID,
+		"from", ptrStringOr(existing.Model, "<none>"),
+		"to", req.Model,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":          "ok",
+		"conversation_id": conversationID,
+		"model":           req.Model,
+		"changed":         true,
+	})
+}
+
+// recordModelSwitchNote inserts a warning message into the conversation noting
+// the model switch. This is a user-visible warning (not sent to the LLM).
+// The LLM doesn't need to be told — it will simply process the full history
+// with whatever model service is now active.
+func (s *Server) recordModelSwitchNote(ctx context.Context, conversationID string, old, new *generated.Conversation) {
+	oldModel := ptrStringOr(old.Model, "unknown")
+	newModel := ptrStringOr(new.Model, "unknown")
+	text := fmt.Sprintf("Model switched from %s to %s. Full conversation history preserved.", oldModel, newModel)
+
+	result, err := s.db.CreateWarningMessage(ctx, conversationID, text, 100, "")
+	if err != nil {
+		s.logger.Error("Failed to record model switch note", "error", err)
+		return
+	}
+	if result.Suppressed {
+		return
+	}
+
+	// Broadcast the warning message to SSE subscribers.
+	go s.notifySubscribersNewMessage(ctx, conversationID, result.Message)
+}
+
+func ptrStringOr(p *string, fallback string) string {
+	if p != nil && *p != "" {
+		return *p
+	}
+	return fallback
+}

--- a/server/switch_model_test.go
+++ b/server/switch_model_test.go
@@ -1,0 +1,276 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	claudetool "shelley.exe.dev/claudetool"
+	"shelley.exe.dev/db"
+	"shelley.exe.dev/db/generated"
+	"shelley.exe.dev/llm"
+	"shelley.exe.dev/loop"
+	"shelley.exe.dev/models"
+)
+
+// multiModelTestManager is an LLMProvider that knows about two models.
+type multiModelTestManager struct {
+	services map[string]llm.Service
+}
+
+func (m *multiModelTestManager) GetService(modelID string) (llm.Service, error) {
+	svc, ok := m.services[modelID]
+	if !ok {
+		return nil, fmt.Errorf("unsupported model: %s", modelID)
+	}
+	return svc, nil
+}
+
+func (m *multiModelTestManager) GetAvailableModels() []string {
+	out := make([]string, 0, len(m.services))
+	for k := range m.services {
+		out = append(out, k)
+	}
+	return out
+}
+
+func (m *multiModelTestManager) HasModel(modelID string) bool {
+	_, ok := m.services[modelID]
+	return ok
+}
+
+func (m *multiModelTestManager) GetModelInfo(modelID string) *models.ModelInfo {
+	return nil
+}
+
+func (m *multiModelTestManager) RefreshCustomModels() error {
+	return nil
+}
+
+func TestSwitchModel(t *testing.T) {
+	t.Parallel()
+
+	// Use the standard test server (single-model) for basic switch validation.
+	server, database, _ := newTestServer(t)
+
+	// Create a conversation.
+	conversation, err := database.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{})
+	if err != nil {
+		t.Fatalf("failed to create conversation: %v", err)
+	}
+	conversationID := conversation.ConversationID
+
+	// Send a first message to pin the model.
+	w := chatPost(t, server, conversationID, ChatRequest{Message: "echo: hello", Model: "predictable"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first chat: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Wait for the loop to record an assistant response so we know the model is pinned.
+	waitForMessages(t, database, conversationID, 3, 5*time.Second) // system + user + agent
+
+	// Verify the model is pinned.
+	conv, err := database.GetConversationByID(context.Background(), conversationID)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if conv.Model == nil || *conv.Model != "predictable" {
+		t.Fatalf("expected model 'predictable', got %v", conv.Model)
+	}
+
+	// Without switching, sending a chat with a different model should fail.
+	w = chatPost(t, server, conversationID, ChatRequest{Message: "echo: world", Model: "some-other-model"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("mismatched model: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Now switch model via the handler. The testLLMManager returns the same
+	// service for any model name, so the switch is valid.
+	switchBody, _ := json.Marshal(SwitchModelRequest{Model: "some-other-model"})
+	req := httptest.NewRequest("POST", "/api/conversation/"+conversationID+"/switch-model", strings.NewReader(string(switchBody)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	server.handleSwitchModel(w, req, conversationID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("switch model: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var switchResp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&switchResp)
+	if switchResp["changed"] != true {
+		t.Fatalf("expected changed=true, got %v", switchResp)
+	}
+
+	// Verify the DB model was updated.
+	conv, err = database.GetConversationByID(context.Background(), conversationID)
+	if err != nil {
+		t.Fatalf("get conversation after switch: %v", err)
+	}
+	if conv.Model == nil || *conv.Model != "some-other-model" {
+		t.Fatalf("expected model 'some-other-model', got %v", conv.Model)
+	}
+
+	// Now sending a message with the new model should work.
+	w = chatPost(t, server, conversationID, ChatRequest{Message: "echo: after switch", Model: "some-other-model"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("chat after switch: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSwitchModelNoOp(t *testing.T) {
+	t.Parallel()
+	server, database, _ := newTestServer(t)
+
+	conversation, err := database.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{})
+	if err != nil {
+		t.Fatalf("failed to create conversation: %v", err)
+	}
+	conversationID := conversation.ConversationID
+
+	// Pin the model.
+	w := chatPost(t, server, conversationID, ChatRequest{Message: "echo: hi", Model: "predictable"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first chat: expected 202, got %d", w.Code)
+	}
+	waitForMessages(t, database, conversationID, 3, 5*time.Second)
+
+	// Switch to the same model = no-op.
+	switchBody, _ := json.Marshal(SwitchModelRequest{Model: "predictable"})
+	req := httptest.NewRequest("POST", "/api/conversation/"+conversationID+"/switch-model", strings.NewReader(string(switchBody)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	server.handleSwitchModel(w, req, conversationID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("no-op switch: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["changed"] != false {
+		t.Fatalf("expected changed=false for no-op, got %v", resp)
+	}
+}
+
+func TestSwitchModelInvalidModel(t *testing.T) {
+	t.Parallel()
+
+	// Create a server with a multi-model manager that only knows about "model-a".
+	testDB, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+	ps := loop.NewPredictableService()
+	mgr := &multiModelTestManager{
+		services: map[string]llm.Service{"model-a": ps},
+	}
+	svr := NewServer(testDB, mgr,
+		claudetool.ToolSetConfig{EnableBrowser: false},
+		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})),
+		true, "model-a", "")
+	svr.hooksDir = t.TempDir()
+
+	conversation, err := testDB.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	// Try to switch to an unknown model.
+	switchBody, _ := json.Marshal(SwitchModelRequest{Model: "nonexistent-model"})
+	req := httptest.NewRequest("POST", "/", strings.NewReader(string(switchBody)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	svr.handleSwitchModel(w, req, conversation.ConversationID)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid model: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSwitchModelPreservesHistory(t *testing.T) {
+	t.Parallel()
+	server, database, _ := newTestServer(t)
+
+	conversation, err := database.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	conversationID := conversation.ConversationID
+
+	// Send a message and wait for the response.
+	w := chatPost(t, server, conversationID, ChatRequest{Message: "echo: first", Model: "predictable"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first chat: expected 202, got %d", w.Code)
+	}
+	waitForMessages(t, database, conversationID, 3, 5*time.Second)
+
+	// Count messages before switch.
+	msgsBefore := listAllMessages(t, database, conversationID)
+	countBefore := len(msgsBefore)
+
+	// Switch model.
+	switchBody, _ := json.Marshal(SwitchModelRequest{Model: "some-other-model"})
+	req := httptest.NewRequest("POST", "/", strings.NewReader(string(switchBody)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	server.handleSwitchModel(w, req, conversationID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("switch: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Count messages after switch — should have exactly 1 more (the warning).
+	msgsAfter := listAllMessages(t, database, conversationID)
+	// The switch inserts a warning message.
+	if len(msgsAfter) != countBefore+1 {
+		t.Fatalf("expected %d messages after switch (was %d + 1 warning), got %d",
+			countBefore+1, countBefore, len(msgsAfter))
+	}
+
+	// The generation should NOT have changed.
+	conv, _ := database.GetConversationByID(context.Background(), conversationID)
+	if conv.CurrentGeneration != conversation.CurrentGeneration {
+		t.Fatalf("expected generation %d unchanged, got %d",
+			conversation.CurrentGeneration, conv.CurrentGeneration)
+	}
+
+	// Verify the warning message content.
+	lastMsg := msgsAfter[len(msgsAfter)-1]
+	if lastMsg.Type != "warning" {
+		t.Fatalf("expected last message type 'warning', got %q", lastMsg.Type)
+	}
+}
+
+// waitForMessages waits until the conversation has at least n messages.
+func waitForMessages(t *testing.T, database *db.DB, conversationID string, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		msgs := listAllMessages(t, database, conversationID)
+		if len(msgs) >= n {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	msgs := listAllMessages(t, database, conversationID)
+	t.Fatalf("timed out waiting for %d messages, have %d", n, len(msgs))
+}
+
+func listAllMessages(t *testing.T, database *db.DB, conversationID string) []generated.Message {
+	t.Helper()
+	var messages []generated.Message
+	err := database.Queries(context.Background(), func(q *generated.Queries) error {
+		var qerr error
+		messages, qerr = q.ListMessages(context.Background(), conversationID)
+		return qerr
+	})
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	return messages
+}

--- a/server/thinking_level.go
+++ b/server/thinking_level.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"shelley.exe.dev/db"
+)
+
+type UpdateThinkingLevelRequest struct {
+	ThinkingLevel string `json:"thinking_level"`
+}
+
+func (s *Server) handleUpdateThinkingLevel(w http.ResponseWriter, r *http.Request, conversationID string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateThinkingLevelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if msg := validateConversationOptions(db.ConversationOptions{ThinkingLevel: req.ThinkingLevel}); msg != "" {
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	conversation, err := s.db.GetConversationByID(ctx, conversationID)
+	if err != nil {
+		http.Error(w, "Conversation not found", http.StatusNotFound)
+		return
+	}
+
+	opts := db.ParseConversationOptions(conversation.ConversationOptions)
+	if opts.ThinkingLevel == req.ThinkingLevel {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":          "ok",
+			"conversation_id": conversationID,
+			"thinking_level":  req.ThinkingLevel,
+			"changed":         false,
+		})
+		return
+	}
+
+	s.mu.Lock()
+	manager, hasManager := s.activeConversations[conversationID]
+	s.mu.Unlock()
+	if hasManager && manager.IsAgentWorking() {
+		http.Error(w, "Cannot change reasoning level while agent is working", http.StatusConflict)
+		return
+	}
+
+	opts.ThinkingLevel = req.ThinkingLevel
+	if err := s.db.UpdateConversationOptions(ctx, conversationID, opts); err != nil {
+		s.logger.Error("Failed to update thinking level", "conversationID", conversationID, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if hasManager {
+		manager.ResetLoop()
+		if err := manager.Hydrate(ctx); err != nil {
+			s.logger.Error("Failed to hydrate after thinking level update", "conversationID", conversationID, "error", err)
+		}
+	}
+
+	conversation, err = s.db.GetConversationByID(ctx, conversationID)
+	if err != nil {
+		s.logger.Error("Failed to re-fetch conversation after thinking level update", "conversationID", conversationID, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	if hasManager {
+		manager.broadcastStream(StreamResponse{Conversation: conversation})
+	}
+	s.publishConversationListUpdate(ConversationListUpdate{Type: "update", Conversation: conversation})
+
+	s.logger.Info("Updated conversation thinking level", "conversationID", conversationID, "thinkingLevel", req.ThinkingLevel)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":          "ok",
+		"conversation_id": conversationID,
+		"thinking_level":  req.ThinkingLevel,
+		"changed":         true,
+	})
+}

--- a/server/thinking_level_test.go
+++ b/server/thinking_level_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"shelley.exe.dev/db"
+)
+
+func TestUpdateThinkingLevel(t *testing.T) {
+	t.Parallel()
+	server, database, _ := newTestServer(t)
+
+	conversation, err := database.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	body, _ := json.Marshal(UpdateThinkingLevelRequest{ThinkingLevel: "high"})
+	req := httptest.NewRequest("POST", "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.handleUpdateThinkingLevel(w, req, conversation.ConversationID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("update thinking level: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	conv, err := database.GetConversationByID(context.Background(), conversation.ConversationID)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	opts := db.ParseConversationOptions(conv.ConversationOptions)
+	if opts.ThinkingLevel != "high" {
+		t.Fatalf("thinking level = %q, want high", opts.ThinkingLevel)
+	}
+}
+
+func TestUpdateThinkingLevelInvalid(t *testing.T) {
+	t.Parallel()
+	server, database, _ := newTestServer(t)
+
+	conversation, err := database.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	body, _ := json.Marshal(UpdateThinkingLevelRequest{ThinkingLevel: "maximum"})
+	req := httptest.NewRequest("POST", "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.handleUpdateThinkingLevel(w, req, conversation.ConversationID)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid thinking level: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateThinkingLevelNoOp(t *testing.T) {
+	t.Parallel()
+	server, database, _ := newTestServer(t)
+
+	conversation, err := database.CreateConversation(context.Background(), nil, true, nil, nil, db.ConversationOptions{ThinkingLevel: "medium"})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	body, _ := json.Marshal(UpdateThinkingLevelRequest{ThinkingLevel: "medium"})
+	req := httptest.NewRequest("POST", "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.handleUpdateThinkingLevel(w, req, conversation.ConversationID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("no-op thinking level: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["changed"] != false {
+		t.Fatalf("changed = %v, want false", resp["changed"])
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -799,6 +799,26 @@ function App() {
     }
   };
 
+  const handleUpdateThinkingLevel = async (
+    conversationId: string,
+    level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh",
+  ) => {
+    try {
+      const result = await api.updateThinkingLevel(conversationId, level);
+      if (result.changed && viewedConversation?.conversation_id === conversationId) {
+        const opts = JSON.parse(viewedConversation.conversation_options || "{}");
+        setViewedConversation({
+          ...viewedConversation,
+          conversation_options: JSON.stringify({ ...opts, thinking_level: level }),
+        });
+      }
+    } catch (err) {
+      console.error("Failed to update reasoning level:", err);
+      setError(err instanceof Error ? err.message : "Failed to update reasoning level");
+      throw err;
+    }
+  };
+
   return (
     <WorkerPoolContextProvider
       poolOptions={diffsPoolOptions}
@@ -850,6 +870,7 @@ function App() {
             }}
             onDistillNewGeneration={handleDistillNewGeneration}
             onSwitchModel={handleSwitchModel}
+            onUpdateThinkingLevel={handleUpdateThinkingLevel}
             mostRecentCwd={mostRecentCwd}
             isDrawerCollapsed={drawerCollapsed}
             onToggleDrawerCollapse={toggleDrawerCollapsed}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -783,6 +783,22 @@ function App() {
     }
   };
 
+  const handleSwitchModel = async (conversationId: string, model: string) => {
+    try {
+      const result = await api.switchModel(conversationId, model);
+      if (result.changed && viewedConversation?.conversation_id === conversationId) {
+        // Optimistically update the viewed conversation so the UI reflects
+        // the switch immediately. The SSE stream will deliver the canonical
+        // update shortly after.
+        setViewedConversation({ ...viewedConversation, model });
+      }
+    } catch (err) {
+      console.error("Failed to switch model:", err);
+      setError(err instanceof Error ? err.message : "Failed to switch model");
+      throw err;
+    }
+  };
+
   return (
     <WorkerPoolContextProvider
       poolOptions={diffsPoolOptions}
@@ -833,6 +849,7 @@ function App() {
               setCurrentConversationId(id);
             }}
             onDistillNewGeneration={handleDistillNewGeneration}
+            onSwitchModel={handleSwitchModel}
             mostRecentCwd={mostRecentCwd}
             isDrawerCollapsed={drawerCollapsed}
             onToggleDrawerCollapse={toggleDrawerCollapsed}

--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -775,6 +775,7 @@ interface ChatInterfaceProps {
     method?: "default" | "compact",
     instructions?: string,
   ) => Promise<void>;
+  onSwitchModel?: (conversationId: string, model: string) => Promise<void>;
   mostRecentCwd?: string | null;
   isDrawerCollapsed?: boolean;
   onToggleDrawerCollapse?: () => void;
@@ -916,6 +917,7 @@ function ChatInterface({
   onConversationUpdate,
   onFirstMessage,
   onDistillNewGeneration,
+  onSwitchModel,
   mostRecentCwd,
   isDrawerCollapsed,
   onToggleDrawerCollapse,
@@ -2062,6 +2064,18 @@ function ChatInterface({
     );
   };
 
+  const handleSwitchModel = async (newModelId: string) => {
+    if (!conversationId || !onSwitchModel) return;
+    if (newModelId === selectedModel) return;
+    try {
+      await onSwitchModel(conversationId, newModelId);
+      setSelectedModel(newModelId);
+    } catch (err) {
+      console.error("Failed to switch model:", err);
+      setError(err instanceof Error ? err.message : "Failed to switch model");
+    }
+  };
+
   const handleStartNewGeneration = async () => {
     if (!conversationId) return;
     const conversation = await api.startNewGeneration(conversationId);
@@ -2467,6 +2481,9 @@ function ChatInterface({
           model={modelsByGeneration.get(generation) || currentConversation?.model}
           models={models}
           thinkingLevel={conversationThinkingLevel}
+          onSwitchModel={onSwitchModel && conversationId ? handleSwitchModel : undefined}
+          onManageModels={onOpenModelsModal}
+          switchDisabled={agentWorking}
         />,
       ];
       const systemMessages = systemMessagesByGeneration.get(generation) || [];
@@ -2887,12 +2904,23 @@ function ChatInterface({
         </div>
       </div>
     ) : (
-      // Active conversation — show ready message and context bar
+      // Active conversation — show ready message, model picker, and context bar
       <div className="status-bar-active">
         <span className="status-message status-ready">
           <span className="hide-on-mobile">Ready on </span>
           {hostname}
         </span>
+        {onSwitchModel && conversationId && (
+          <div className="status-field status-field-model hide-on-mobile">
+            <ModelPicker
+              models={models}
+              selectedModel={selectedModel}
+              onSelectModel={handleSwitchModel}
+              onManageModels={() => onOpenModelsModal?.()}
+              disabled={agentWorking}
+            />
+          </div>
+        )}
         {(currentConversation?.cwd || selectedCwd) && (
           <span
             className="status-cwd-readonly hide-on-mobile"

--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -776,6 +776,7 @@ interface ChatInterfaceProps {
     instructions?: string,
   ) => Promise<void>;
   onSwitchModel?: (conversationId: string, model: string) => Promise<void>;
+  onUpdateThinkingLevel?: (conversationId: string, level: ThinkingLevel) => Promise<void>;
   mostRecentCwd?: string | null;
   isDrawerCollapsed?: boolean;
   onToggleDrawerCollapse?: () => void;
@@ -918,6 +919,7 @@ function ChatInterface({
   onFirstMessage,
   onDistillNewGeneration,
   onSwitchModel,
+  onUpdateThinkingLevel,
   mostRecentCwd,
   isDrawerCollapsed,
   onToggleDrawerCollapse,
@@ -953,6 +955,9 @@ function ChatInterface({
       source?: string;
       ready: boolean;
       max_context_tokens?: number;
+      base_url?: string;
+      api_type?: string;
+      supports_images?: boolean;
     }>
   >(window.__SHELLEY_INIT__?.models || []);
   const THINKING_LEVEL_KEY = "shelley.thinkingLevel";
@@ -2076,6 +2081,18 @@ function ChatInterface({
     }
   };
 
+  const handleUpdateThinkingLevel = async (level: ThinkingLevel) => {
+    if (!conversationId || !onUpdateThinkingLevel) return;
+    if (level === effectiveThinkingLevel) return;
+    try {
+      await onUpdateThinkingLevel(conversationId, level);
+      setThinkingLevel(level);
+    } catch (err) {
+      console.error("Failed to update reasoning level:", err);
+      setError(err instanceof Error ? err.message : "Failed to update reasoning level");
+    }
+  };
+
   const handleStartNewGeneration = async () => {
     if (!conversationId) return;
     const conversation = await api.startNewGeneration(conversationId);
@@ -2100,6 +2117,7 @@ function ChatInterface({
       return null;
     }
   }, [currentConversation?.conversation_options]);
+  const effectiveThinkingLevel = (conversationThinkingLevel || DEFAULT_THINKING_LEVEL) as ThinkingLevel;
 
   const handleUnarchive = async () => {
     if (!conversationId) return;
@@ -2720,6 +2738,9 @@ function ChatInterface({
         <span className="status-model-readonly hide-on-mobile" title="Active model">
           {selectedModelDisplayName}
         </span>
+        <span className="status-model-readonly hide-on-mobile" title="Reasoning level">
+          {t("thinkingLabel")}: {effectiveThinkingLevel}
+        </span>
         {(currentConversation?.cwd || selectedCwd) && (
           <span
             className="status-cwd-readonly hide-on-mobile"
@@ -2920,6 +2941,21 @@ function ChatInterface({
               selectedModel={selectedModel}
               onSelectModel={handleSwitchModel}
               onManageModels={() => onOpenModelsModal?.()}
+              disabled={agentWorking}
+            />
+          </div>
+        )}
+        {onUpdateThinkingLevel && conversationId && (
+          <div className="status-field status-field-thinking hide-on-mobile">
+            <span
+              className="status-field-label"
+              title="Reasoning effort the model spends before answering"
+            >
+              {t("thinkingLabel")}
+            </span>
+            <ThinkingLevelPicker
+              value={effectiveThinkingLevel}
+              onChange={handleUpdateThinkingLevel}
               disabled={agentWorking}
             />
           </div>

--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -2717,6 +2717,9 @@ function ChatInterface({
             <span className="status-stop-label">{cancelling ? "Cancelling..." : "Stop"}</span>
           </button>
         </div>
+        <span className="status-model-readonly hide-on-mobile" title="Active model">
+          {selectedModelDisplayName}
+        </span>
         {(currentConversation?.cwd || selectedCwd) && (
           <span
             className="status-cwd-readonly hide-on-mobile"

--- a/ui/src/components/ModelBar.tsx
+++ b/ui/src/components/ModelBar.tsx
@@ -1,18 +1,29 @@
 import React from "react";
 import { Model } from "../types";
+import ModelPicker from "./ModelPicker";
 
 interface ModelBarProps {
   model?: string | null;
   models?: Model[];
   thinkingLevel?: string | null;
+  /** When set, the model name becomes a clickable picker that calls this on selection. */
+  onSwitchModel?: (modelId: string) => void;
+  onManageModels?: () => void;
+  switchDisabled?: boolean;
 }
 
-function ModelBar({ model, models = [], thinkingLevel }: ModelBarProps) {
+function ModelBar({
+  model,
+  models = [],
+  thinkingLevel,
+  onSwitchModel,
+  onManageModels,
+  switchDisabled,
+}: ModelBarProps) {
   if (!model) {
     return null;
   }
 
-  // Find the model object to get display name
   const modelObj = models.find((m) => m.id === model);
   const displayName = modelObj?.display_name || model;
 
@@ -21,7 +32,17 @@ function ModelBar({ model, models = [], thinkingLevel }: ModelBarProps) {
       <div className="model-bar-summary">
         <span className="model-bar-icon">🤖</span>
         <span className="model-bar-label">Model</span>
-        <span className="model-bar-name">{displayName}</span>
+        {onSwitchModel ? (
+          <ModelPicker
+            models={models}
+            selectedModel={model}
+            onSelectModel={onSwitchModel}
+            onManageModels={onManageModels || (() => {})}
+            disabled={switchDisabled}
+          />
+        ) : (
+          <span className="model-bar-name">{displayName}</span>
+        )}
         {thinkingLevel && (
           <>
             <span className="model-bar-label" title="Reasoning effort">

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -223,6 +223,25 @@ class ApiService {
     return response.json();
   }
 
+  async updateThinkingLevel(
+    conversationId: string,
+    thinkingLevel: "off" | "minimal" | "low" | "medium" | "high" | "xhigh",
+  ): Promise<{ status: string; conversation_id: string; thinking_level: string; changed: boolean }> {
+    const response = await fetch(
+      `${this.baseUrl}/conversation/${conversationId}/thinking-level`,
+      {
+        method: "POST",
+        headers: this.postHeaders,
+        body: JSON.stringify({ thinking_level: thinkingLevel }),
+      },
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Failed to update reasoning level: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
   async startNewGeneration(conversationId: string): Promise<Conversation> {
     const response = await fetch(`${this.baseUrl}/conversation/${conversationId}/new-generation`, {
       method: "POST",

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -204,6 +204,25 @@ class ApiService {
     return response.json();
   }
 
+  async switchModel(
+    conversationId: string,
+    model: string,
+  ): Promise<{ status: string; conversation_id: string; model: string; changed: boolean }> {
+    const response = await fetch(
+      `${this.baseUrl}/conversation/${conversationId}/switch-model`,
+      {
+        method: "POST",
+        headers: this.postHeaders,
+        body: JSON.stringify({ model }),
+      },
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Failed to switch model: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
   async startNewGeneration(conversationId: string): Promise<Conversation> {
     const response = await fetch(`${this.baseUrl}/conversation/${conversationId}/new-generation`, {
       method: "POST",

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4695,6 +4695,17 @@ svg {
   unicode-bidi: plaintext;
 }
 
+.status-model-readonly {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  max-width: 20ch;
+}
+
 .status-stop-button {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Why:
I often want to switch models in between different prompts, but on the same thread. I also want to have different reasoning levels depending on my prompt.

### How:
Treat model-switching as drop-in context replacement: comes with tradeoffs, mainly in cache continuity and any provider-specific transient request state. 

### Consideration:
- Should maybe warn that model switching resets provider-specific state?
- Should we maybe compact the conversation before switching the model?

### Testing:
PR is draft for now. Final version will be reviewed manually before submission.
