### PR TITLE
[UI] Add a slash command popup helper

### DIFF
--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -33,6 +33,7 @@ import MessageSelectionToolbar from "./MessageSelectionToolbar";
 import { buildMessageQuote } from "../utils/messageQuote";
 import { tildifyPath } from "../utils/tildify";
 import { handleModifiedNavClick } from "../utils/openInNewTab";
+import { SLASH_COMMANDS } from "../utils/slashCommands";
 import GitGraphViewer from "./GitGraphViewer";
 import AgentsMdEditorModal from "./AgentsMdEditorModal";
 import BashTool from "./BashTool";
@@ -1843,7 +1844,7 @@ function ChatInterface({
 
     // "/fork" forks the current conversation (all messages) into a new one and
     // navigates to it.
-    if (trimmedMessage === "/fork") {
+    if (trimmedMessage === SLASH_COMMANDS.FORK.command) {
       await forkConversation();
       return;
     }
@@ -1852,7 +1853,7 @@ function ChatInterface({
     // "/diff" opens the diff viewer (mirroring the command palette action).
     // "/new <prompt>" starts a new conversation and sends <prompt> as the
     // first message; "/new" with no prompt just clears the conversation.
-    if (trimmedMessage === "/diff") {
+    if (trimmedMessage === SLASH_COMMANDS.DIFF.command) {
       setShowDiffViewer(true);
       return;
     }
@@ -1861,13 +1862,19 @@ function ChatInterface({
     // generation (summarize older messages, keep recent ones verbatim).
     // Any text after "/compact" is free-form guidance steering what the
     // summary should preserve or emphasize.
-    if (trimmedMessage === "/compact" || trimmedMessage.startsWith("/compact ")) {
-      const instructions = trimmedMessage.slice("/compact".length).trim();
+    if (
+      trimmedMessage === SLASH_COMMANDS.COMPACT.command ||
+      trimmedMessage.startsWith(`${SLASH_COMMANDS.COMPACT.command} `)
+    ) {
+      const instructions = trimmedMessage.slice(SLASH_COMMANDS.COMPACT.command.length).trim();
       await handleDistillCompactNewGeneration(instructions || undefined);
       return;
     }
-    if (trimmedMessage === "/new" || trimmedMessage.startsWith("/new ")) {
-      const prompt = trimmedMessage.slice("/new".length).trim();
+    if (
+      trimmedMessage === SLASH_COMMANDS.NEW.command ||
+      trimmedMessage.startsWith(`${SLASH_COMMANDS.NEW.command} `)
+    ) {
+      const prompt = trimmedMessage.slice(SLASH_COMMANDS.NEW.command.length).trim();
       // Clear current conversation (carries cwd over via localStorage).
       onNewConversation();
       if (!prompt || !onFirstMessage) return;

--- a/ui/src/components/MessageInput.tsx
+++ b/ui/src/components/MessageInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useI18n } from "../i18n";
 import { pickPlaceholderHint } from "../utils/placeholderHints";
+import { SLASH_COMMANDS } from "../utils/slashCommands";
 
 // Web Speech API types
 interface SpeechRecognitionEvent extends Event {
@@ -138,7 +139,10 @@ function MessageInput({
     return window.innerWidth < 480;
   });
   const [showQueueMenu, setShowQueueMenu] = useState(false);
+  const [slashMenuSelectedIndex, setSlashMenuSelectedIndex] = useState(0);
+  const [slashMenuDismissed, setSlashMenuDismissed] = useState(false);
   const queueMenuRef = useRef<HTMLDivElement>(null);
+  const slashMenuRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
@@ -535,10 +539,103 @@ function MessageInput({
     }
   };
 
+  const isDisabled = disabled;
+  const canSubmit = hasContent && !isDisabled && !submitting && uploadsInProgress === 0;
+
+  // Check if user is typing a shell command (starts with !)
+  const isShellMode = message.trimStart().startsWith("!");
+  const slashPrefixMatch = message.match(/^\/[a-zA-Z0-9_-]*$/);
+  const slashQuery = slashPrefixMatch ? slashPrefixMatch[0].slice(1).toLowerCase() : null;
+  const slashSuggestions = useMemo(() => {
+    if (slashQuery === null) return [];
+    return Object.values(SLASH_COMMANDS).filter((item) =>
+      item.command.slice(1).startsWith(slashQuery),
+    );
+  }, [slashQuery]);
+  const exactSlashCommand = slashSuggestions.some((item) => item.command.slice(1) === slashQuery);
+  const showSlashMenu =
+    slashQuery !== null &&
+    !slashMenuDismissed &&
+    !exactSlashCommand &&
+    slashSuggestions.length > 0 &&
+    !isDisabled &&
+    !isShellMode;
+
+  useEffect(() => {
+    setSlashMenuSelectedIndex(0);
+  }, [slashQuery]);
+
+  useEffect(() => {
+    if (message.length === 0) setSlashMenuDismissed(false);
+  }, [message]);
+
+  useEffect(() => {
+    if (message === SLASH_COMMANDS.SHELL.command) {
+      setMessage("!");
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    }
+  }, [message, setMessage]);
+
+  const chooseSlashCommand = useCallback(
+    async (index: number) => {
+      const item = slashSuggestions[index];
+      if (!item) return;
+      if (!item.takesArgs) {
+        setMessage("");
+        setSlashMenuDismissed(true);
+        onDraftSendStarted?.();
+        try {
+          await onSend(item.command);
+          onDraftCleared?.();
+        } catch {
+          setMessage(item.command);
+        }
+        return;
+      }
+      if (item.command === SLASH_COMMANDS.SHELL.command) {
+        setMessage("!");
+        requestAnimationFrame(() => textareaRef.current?.focus());
+        return;
+      }
+      setMessage(`${item.command} `);
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    },
+    [onDraftCleared, onDraftSendStarted, onSend, setMessage, slashSuggestions],
+  );
+
+  useEffect(() => {
+    if (!showSlashMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (slashMenuRef.current?.contains(e.target as Node)) return;
+      setSlashMenuDismissed(true);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showSlashMenu]);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // Don't submit while IME is composing (e.g., converting Japanese hiragana to kanji)
     if (e.nativeEvent.isComposing) {
       return;
+    }
+    if (showSlashMenu) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSlashMenuSelectedIndex((index) => (index + 1) % slashSuggestions.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSlashMenuSelectedIndex(
+          (index) => (index - 1 + slashSuggestions.length) % slashSuggestions.length,
+        );
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        void chooseSlashCommand(slashMenuSelectedIndex);
+        return;
+      }
     }
     // Escape blurs the textarea, so that follow-up shortcuts like
     // Cmd+ArrowDown (scroll conversation to bottom) work without
@@ -619,17 +716,12 @@ function MessageInput({
     };
   }, []);
 
-  const isDisabled = disabled;
-  const canSubmit = hasContent && !isDisabled && !submitting && uploadsInProgress === 0;
-
   const isDraggingOver = dragCounter > 0;
-  // Check if user is typing a shell command (starts with !)
-  const isShellMode = message.trimStart().startsWith("!");
   // Note: injectedText is auto-inserted via useEffect, no manual UI needed
 
   return (
     <div
-      className={`message-input-container ${isDraggingOver ? "drag-over" : ""} ${isShellMode ? "shell-mode" : ""}`}
+      className={`message-input-container ${isDraggingOver ? "drag-over" : ""} ${isShellMode ? "shell-mode" : ""} ${showSlashMenu ? "slash-menu-open" : ""}`}
       onDragOver={handleDragOver}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
@@ -704,6 +796,31 @@ function MessageInput({
           </div>
         )}
         <div className="textarea-wrapper">
+          {showSlashMenu && (
+            <div
+              ref={slashMenuRef}
+              className="slash-command-menu"
+              role="listbox"
+              aria-label="Slash commands"
+              data-testid="slash-command-menu"
+            >
+              {slashSuggestions.map((item, index) => (
+                <button
+                  key={item.command}
+                  type="button"
+                  className={`slash-command-item${index === slashMenuSelectedIndex ? " selected" : ""}`}
+                  role="option"
+                  aria-selected={index === slashMenuSelectedIndex}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseEnter={() => setSlashMenuSelectedIndex(index)}
+                  onClick={() => void chooseSlashCommand(index)}
+                >
+                  <span className="slash-command-name">{item.command}</span>
+                  <span className="slash-command-description">{item.description}</span>
+                </button>
+              ))}
+            </div>
+          )}
           {isShellMode && (
             <div className="shell-mode-indicator" title="This will run as a shell command">
               <svg

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2325,6 +2325,11 @@ button {
   margin: 0 auto;
 }
 
+.message-input-container.slash-menu-open .message-input-form {
+  position: relative;
+  z-index: 130;
+}
+
 .message-textarea {
   width: 100%;
   box-sizing: border-box;
@@ -2749,6 +2754,69 @@ button {
   position: relative;
   flex: 1;
   min-width: 0;
+}
+
+.slash-command-menu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 120;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: min(260px, 40vh);
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
+}
+
+.slash-command-item {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.slash-command-item:hover,
+.slash-command-item.selected {
+  background: var(--gray-100);
+}
+
+.dark .slash-command-item:hover,
+.dark .slash-command-item.selected {
+  background: var(--gray-700);
+}
+
+.slash-command-name {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--primary);
+  white-space: nowrap;
+}
+
+.slash-command-description {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .message-input-container.shell-mode .message-textarea::placeholder {

--- a/ui/src/utils/placeholderHints.ts
+++ b/ui/src/utils/placeholderHints.ts
@@ -7,6 +7,8 @@
 // substitute the localized message placeholder via i18n. All other hints are
 // English easter-egg style tips and are intentionally not i18n'd.
 
+import { SLASH_COMMANDS } from "./slashCommands";
+
 export type PlaceholderHintPlatform = "any" | "desktop" | "mobile";
 
 export interface PlaceholderHint {
@@ -36,13 +38,13 @@ export const PLACEHOLDER_HINTS: PlaceholderHint[] = [
   },
   {
     id: "slash-diff",
-    text: "/diff opens the diff viewer",
+    text: `${SLASH_COMMANDS.DIFF.command} ${SLASH_COMMANDS.DIFF.description}`,
     platform: "any",
     weight: 1,
   },
   {
     id: "slash-new",
-    text: "/new <prompt> starts a new conversation",
+    text: `${SLASH_COMMANDS.NEW.command} <prompt> ${SLASH_COMMANDS.NEW.description}`,
     platform: "any",
     weight: 1,
   },

--- a/ui/src/utils/slashCommands.ts
+++ b/ui/src/utils/slashCommands.ts
@@ -1,0 +1,33 @@
+export interface SlashCommand {
+  command: `/${string}`;
+  description: string;
+  takesArgs: boolean;
+}
+
+export const SLASH_COMMANDS = {
+  FORK: {
+    command: "/fork",
+    description: "forks this conversation",
+    takesArgs: false,
+  },
+  DIFF: {
+    command: "/diff",
+    description: "opens the diff viewer",
+    takesArgs: false,
+  },
+  SHELL: {
+    command: "/shell",
+    description: "runs in shell (! alias)",
+    takesArgs: true,
+  },
+  COMPACT: {
+    command: "/compact",
+    description: "compacts this conversation",
+    takesArgs: true,
+  },
+  NEW: {
+    command: "/new",
+    description: "starts a new conversation",
+    takesArgs: true,
+  },
+} as const satisfies Record<string, SlashCommand>;

--- a/ui/src/vue/components/ChatInterface.vue
+++ b/ui/src/vue/components/ChatInterface.vue
@@ -634,6 +634,7 @@ import { tildifyPath } from "../../utils/tildify";
 import { handleModifiedNavClick } from "../utils/openInNewTab";
 import { isAutoExpandTool } from "../../utils/toolMeta";
 import { formatDay } from "../../utils/messageTime";
+import { SLASH_COMMANDS } from "../../utils/slashCommands";
 import { coalesceMessages, type CoalescedItem } from "./coalesce";
 import type { RenderNode, GenerationBlock } from "./renderNode";
 import type { EphemeralTerminal } from "./terminalTypes";
@@ -1427,21 +1428,27 @@ async function sendMessage(message: string) {
   if (!message.trim() || sending.value) return;
   const trimmedMessage = message.trim();
 
-  if (trimmedMessage === "/fork") {
+  if (trimmedMessage === SLASH_COMMANDS.FORK.command) {
     await forkConversation();
     return;
   }
-  if (trimmedMessage === "/diff") {
+  if (trimmedMessage === SLASH_COMMANDS.DIFF.command) {
     showDiffViewer.value = true;
     return;
   }
-  if (trimmedMessage === "/compact" || trimmedMessage.startsWith("/compact ")) {
-    const instructions = trimmedMessage.slice("/compact".length).trim();
+  if (
+    trimmedMessage === SLASH_COMMANDS.COMPACT.command ||
+    trimmedMessage.startsWith(`${SLASH_COMMANDS.COMPACT.command} `)
+  ) {
+    const instructions = trimmedMessage.slice(SLASH_COMMANDS.COMPACT.command.length).trim();
     await handleDistillCompactNewGeneration(instructions || undefined);
     return;
   }
-  if (trimmedMessage === "/new" || trimmedMessage.startsWith("/new ")) {
-    const prompt = trimmedMessage.slice("/new".length).trim();
+  if (
+    trimmedMessage === SLASH_COMMANDS.NEW.command ||
+    trimmedMessage.startsWith(`${SLASH_COMMANDS.NEW.command} `)
+  ) {
+    const prompt = trimmedMessage.slice(SLASH_COMMANDS.NEW.command.length).trim();
     props.onNewConversation();
     if (!prompt || !props.onFirstMessage) return;
     try {

--- a/ui/src/vue/components/MessageInput.vue
+++ b/ui/src/vue/components/MessageInput.vue
@@ -27,7 +27,7 @@
        use the `:on-send` / `:on-queue` function props. -->
 <template>
   <div
-    :class="`message-input-container ${isDraggingOver ? 'drag-over' : ''} ${isShellMode ? 'shell-mode' : ''}`"
+    :class="`message-input-container ${isDraggingOver ? 'drag-over' : ''} ${isShellMode ? 'shell-mode' : ''} ${showSlashMenu ? 'slash-menu-open' : ''}`"
     @dragover="handleDragOver"
     @dragenter="handleDragEnter"
     @dragleave="handleDragLeave"
@@ -97,6 +97,29 @@
         </div>
       </div>
       <div class="textarea-wrapper">
+        <div
+          v-if="showSlashMenu"
+          ref="slashMenuRef"
+          class="slash-command-menu"
+          role="listbox"
+          aria-label="Slash commands"
+          data-testid="slash-command-menu"
+        >
+          <button
+            v-for="(item, index) in slashSuggestions"
+            :key="item.command"
+            type="button"
+            :class="`slash-command-item${index === slashMenuSelectedIndex ? ' selected' : ''}`"
+            role="option"
+            :aria-selected="index === slashMenuSelectedIndex"
+            @mousedown.prevent
+            @mouseenter="slashMenuSelectedIndex = index"
+            @click="chooseSlashCommand(index)"
+          >
+            <span class="slash-command-name">{{ item.command }}</span>
+            <span class="slash-command-description">{{ item.description }}</span>
+          </button>
+        </div>
         <div
           v-if="isShellMode"
           class="shell-mode-indicator"
@@ -263,6 +286,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "../composables/i18n";
 import { pickPlaceholderHint } from "../../utils/placeholderHints";
+import { SLASH_COMMANDS } from "../../utils/slashCommands";
 
 // Web Speech API types
 interface SpeechRecognitionEvent extends Event {
@@ -399,8 +423,11 @@ const dragCounter = ref(0);
 const isListening = ref(false);
 const isSmallScreen = ref(typeof window !== "undefined" ? window.innerWidth < 480 : false);
 const showQueueMenu = ref(false);
+const slashMenuSelectedIndex = ref(0);
+const slashMenuDismissed = ref(false);
 
 const queueMenuRef = ref<HTMLDivElement | null>(null);
+const slashMenuRef = ref<HTMLDivElement | null>(null);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 let recognition: SpeechRecognition | null = null;
@@ -668,6 +695,74 @@ const canSubmit = computed(
 );
 const isDraggingOver = computed(() => dragCounter.value > 0);
 const isShellMode = computed(() => message.value.trimStart().startsWith("!"));
+const slashQuery = computed(() => {
+  const match = message.value.match(/^\/[a-zA-Z0-9_-]*$/);
+  return match ? match[0].slice(1).toLowerCase() : null;
+});
+const slashSuggestions = computed(() => {
+  if (slashQuery.value === null) return [];
+  return Object.values(SLASH_COMMANDS).filter((item) =>
+    item.command.slice(1).startsWith(slashQuery.value!),
+  );
+});
+const exactSlashCommand = computed(() =>
+  slashSuggestions.value.some((item) => item.command.slice(1) === slashQuery.value),
+);
+const showSlashMenu = computed(
+  () =>
+    slashQuery.value !== null &&
+    !slashMenuDismissed.value &&
+    !exactSlashCommand.value &&
+    slashSuggestions.value.length > 0 &&
+    !isDisabled.value &&
+    !isShellMode.value,
+);
+
+watch(slashQuery, () => {
+  slashMenuSelectedIndex.value = 0;
+});
+
+watch(message, (value) => {
+  if (value.length === 0) slashMenuDismissed.value = false;
+  if (value === SLASH_COMMANDS.SHELL.command) {
+    setMessage("!");
+    requestAnimationFrame(() => textareaRef.value?.focus());
+  }
+});
+
+async function chooseSlashCommand(index: number) {
+  const item = slashSuggestions.value[index];
+  if (!item) return;
+  if (!item.takesArgs) {
+    setMessage("");
+    slashMenuDismissed.value = true;
+    emit("draft-send-started");
+    try {
+      await props.onSend(item.command);
+      emit("draft-cleared");
+    } catch {
+      setMessage(item.command);
+    }
+    return;
+  }
+  if (item.command === SLASH_COMMANDS.SHELL.command) {
+    setMessage("!");
+    requestAnimationFrame(() => textareaRef.value?.focus());
+    return;
+  }
+  setMessage(`${item.command} `);
+  requestAnimationFrame(() => textareaRef.value?.focus());
+}
+
+function onSlashMenuOutside(e: MouseEvent) {
+  if (slashMenuRef.value?.contains(e.target as Node)) return;
+  slashMenuDismissed.value = true;
+}
+
+watch(showSlashMenu, (open) => {
+  if (open) document.addEventListener("mousedown", onSlashMenuOutside);
+  else document.removeEventListener("mousedown", onSlashMenuOutside);
+});
 
 async function handleSubmit(e: Event) {
   e.preventDefault();
@@ -754,6 +849,26 @@ function onTextareaFocus() {
 function handleKeyDown(e: KeyboardEvent) {
   // Don't submit while IME is composing.
   if (e.isComposing) return;
+  if (showSlashMenu.value) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      slashMenuSelectedIndex.value =
+        (slashMenuSelectedIndex.value + 1) % slashSuggestions.value.length;
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      slashMenuSelectedIndex.value =
+        (slashMenuSelectedIndex.value - 1 + slashSuggestions.value.length) %
+        slashSuggestions.value.length;
+      return;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      void chooseSlashCommand(slashMenuSelectedIndex.value);
+      return;
+    }
+  }
   // Escape blurs the textarea so follow-up shortcuts work.
   if (e.key === "Escape") {
     textareaRef.value?.blur();
@@ -824,6 +939,7 @@ onUnmounted(() => {
     window.visualViewport.removeEventListener("resize", handleViewportResize);
   }
   document.removeEventListener("mousedown", onQueueMenuOutside);
+  document.removeEventListener("mousedown", onSlashMenuOutside);
   if (recognition) recognition.abort();
   attachments.value.forEach((a) => {
     if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);


### PR DESCRIPTION
## Why

The slash commands are super useful - especially on mobile - but they're a bit hidden aside from the placeholder hints.

## What

- Adds a popup depicting the available slash commands when the first char of the input is `/`
- The commands can be selected by 
  - touch/click
  - Up / down arrows and tab/enter
- `/diff`, `/fork` are applied immediately
- `/shell` is an alias for `!`
- `/new`, `/compact` populate the input and allow for extra user input
- Clicking outside the menu dismisses it until the input is cleared and the user inputs a `/` as the first character again

### Light mode

https://github.com/user-attachments/assets/a647a23a-1284-4ef0-aba7-437d48054f5f

### Dark Mode

https://github.com/user-attachments/assets/b5e2f130-9265-4769-aa53-d2f7ccba29c4

### Mobile

https://github.com/user-attachments/assets/9bc251eb-88ac-44a2-a9df-bf249bfc97cc


