### PR TITLE
fix: ensure input_schema is always present for Vertex AI proxy compatibility

### DIFF
--- a/llm/ant/ant.go
+++ b/llm/ant/ant.go
@@ -608,11 +608,18 @@ func fromLLMToolChoice(tc *llm.ToolChoice) *toolChoice {
 }
 
 func fromLLMTool(t *llm.Tool) *tool {
+	schema := t.InputSchema
+	if schema == nil {
+		// Some proxies (e.g. Vertex AI via Langdock) strictly require input_schema
+		// to be present on every tool, even server-side tools where Anthropic's
+		// own API accepts omitting it. Default to an empty object schema.
+		schema = json.RawMessage(`{"type":"object","properties":{}}`)
+	}
 	return &tool{
 		Name:         t.Name,
 		Type:         t.Type,
 		Description:  t.Description,
-		InputSchema:  t.InputSchema,
+		InputSchema:  schema,
 		CacheControl: fromLLMCache(t.Cache),
 	}
 }


### PR DESCRIPTION
## Problem

When using Shelley with a custom Anthropic-compatible endpoint backed by Vertex AI (e.g. Langdock), requests fail with:

```
LLM request failed: status 400 Bad Request: {"message":[{"expected":"object","code":"invalid_type","path":["tools",9,"input_schema"],"message":"Invalid input: expected object, received undefined"}]}
```

## Root Cause

Server-side tools (e.g. `web_search_20250305`) are created without an `InputSchema` in `claudetool/toolset.go`. The wire struct in `ant.go` uses `json:"input_schema,omitempty"`, so a `nil` schema causes the `input_schema` key to be **completely absent** from the JSON.

Anthropic's own API is lenient and accepts this. However, Vertex AI-backed proxies strictly require `input_schema` to be present as an object on every tool.

## Fix

In `fromLLMTool()`, default to an empty object schema `{"type":"object","properties":{}}` when `InputSchema` is nil. This is the defensive serialization-layer fix that covers any current or future tool that omits `InputSchema`.

## Testing

Verified the fix resolves 400 errors against Langdock's Vertex AI proxy (`https://api.langdock.com/anthropic/eu/v1/messages`) while remaining fully compatible with the official Anthropic API.