### PR TITLE
ui: clarify orchestrator mode behavior

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4000,6 +4000,17 @@ svg {
   flex: 1;
 }
 
+.tool-override-warning {
+  margin: 0.35rem 0 0.45rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(202, 138, 4, 0.35);
+  border-radius: 0.375rem;
+  background: rgba(202, 138, 4, 0.12);
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+
 .tool-override-suboption {
   padding-left: 1rem;
   justify-content: flex-start;

--- a/ui/src/vue/components/ChatInterface.vue
+++ b/ui/src/vue/components/ChatInterface.vue
@@ -646,7 +646,8 @@ const toolOverrideCount = computed(() => Object.keys(toolOverrides.value).length
 
 const orchestratorPseudoTool = {
   name: "orchestrator",
-  summary: "Shelley orchestrator mode (delegates to subagents).",
+  summary:
+    "Advanced mode: the main agent delegates execution to subagents instead of using shell/file tools directly.",
   default_on: false,
 };
 const toolOverrideList = computed(() => [orchestratorPseudoTool, ...availableTools.value]);

--- a/ui/src/vue/components/ChatStatusContent.vue
+++ b/ui/src/vue/components/ChatStatusContent.vue
@@ -161,6 +161,14 @@
               </div>
               <div
                 v-if="tool.name === 'orchestrator' && toolOverrides['orchestrator'] === 'on'"
+                class="tool-override-warning"
+              >
+                Orchestrator changes the conversation mode: the main agent will plan and delegate
+                work to subagents, and will not run shell or edit files directly. Leave this off
+                for normal coding sessions.
+              </div>
+              <div
+                v-if="tool.name === 'orchestrator' && toolOverrides['orchestrator'] === 'on'"
                 class="tool-override-row tool-override-suboption"
               >
                 <label class="tool-override-suboption-label" for="subagent-backend-select"


### PR DESCRIPTION
## Summary
- Clarify that orchestrator is an advanced conversation mode, not just another tool
- Show a warning when orchestrator is enabled that the main agent delegates execution and will not run shell/file tools directly
- Recommend leaving orchestrator off for normal coding sessions

## Testing
- pnpm --dir ui run --silent build
- go test ./server ./claudetool
