### PR TITLE
Enhance `one_shot_llm` to help non-vision models 

### DIFF
--- a/claudetool/browse/browse.go
+++ b/claudetool/browse/browse.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -608,17 +607,16 @@ func (b *BrowseTools) screenshotRun(ctx context.Context, input screenshotInput) 
 	// (potentially) downscaled. A byte-overflow that can't be fixed by
 	// downscaling produces an error so we never send a request the API will
 	// reject.
-	imageData, format, resized, err := prepareImageForModel(ctx, buf, "png", screenshotPath)
+	maxDimension, maxBytes := imageLimits(ctx)
+	prepared, err := imageutil.Prepare(buf, screenshotPath, maxDimension, maxBytes)
 	if err != nil {
 		return llm.ErrorToolOut(err)
 	}
 
-	base64Data := base64.StdEncoding.EncodeToString(imageData)
-	mediaType := "image/" + format
-	widthPx, heightPx, _ := imageutil.DecodeDimensions(imageData)
+	base64Data := base64.StdEncoding.EncodeToString(prepared.Data)
 
 	description := fmt.Sprintf("Screenshot taken (saved as %s)", screenshotPath)
-	if resized {
+	if prepared.Resized {
 		description += " [resized to fit model limits]"
 	}
 
@@ -629,10 +627,10 @@ func (b *BrowseTools) screenshotRun(ctx context.Context, input screenshotInput) 
 		},
 		{
 			Type:          llm.ContentTypeText,
-			MediaType:     mediaType,
+			MediaType:     prepared.MediaType,
 			Data:          base64Data,
-			DisplayWidth:  widthPx,
-			DisplayHeight: heightPx,
+			DisplayWidth:  prepared.Width,
+			DisplayHeight: prepared.Height,
 		},
 	}, Display: display}
 }
@@ -1053,48 +1051,19 @@ func (b *BrowseTools) readImageRun(ctx context.Context, input readImageInput) ll
 		return llm.ErrorfToolOut("failed to read image file: %w", err)
 	}
 
-	// Convert HEIC to PNG if needed (Go's image library doesn't support HEIC)
-	converted := false
-	if imageutil.IsHEIC(imageData) {
-		imageData, err = imageutil.ConvertHEICToPNG(imageData)
-		if err != nil {
-			return llm.ErrorfToolOut("failed to convert HEIC image: %w", err)
-		}
-		converted = true
-	}
-
-	detectedType := http.DetectContentType(imageData)
-	if !strings.HasPrefix(detectedType, "image/") {
-		return llm.ErrorfToolOut("file is not an image: %s", detectedType)
-	}
-
-	// Fully decode to reject truncated/corrupt images (e.g. an upload cut short
-	// by a flaky connection) whose header still sniffs as a valid image. Sending
-	// such bytes to the model makes the provider 400 the whole request, which
-	// permanently wedges the conversation; failing here keeps it recoverable.
-	if err := imageutil.Validate(imageData); err != nil {
-		return llm.ErrorfToolOut("image file appears corrupt or truncated (%s); re-upload or pick a different file: %v", input.Path, err)
-	}
-
-	// Fit the image inside the model's per-image limits. Dimension overflow
-	// is fixed transparently by downscaling; byte overflow that can't be
-	// fixed by downscaling becomes a tool error so we never send a request
-	// the API will reject.
-	format := strings.TrimPrefix(detectedType, "image/")
-	imageData, format, resized, err := prepareImageForModel(ctx, imageData, format, input.Path)
+	maxDimension, maxBytes := imageLimits(ctx)
+	prepared, err := imageutil.Prepare(imageData, input.Path, maxDimension, maxBytes)
 	if err != nil {
 		return llm.ErrorToolOut(err)
 	}
 
-	base64Data := base64.StdEncoding.EncodeToString(imageData)
-	mediaType := "image/" + format
-	widthPx, heightPx, _ := imageutil.DecodeDimensions(imageData)
+	base64Data := base64.StdEncoding.EncodeToString(prepared.Data)
 
-	description := fmt.Sprintf("Image from %s (type: %s)", input.Path, mediaType)
-	if converted {
+	description := fmt.Sprintf("Image from %s (type: %s)", input.Path, prepared.MediaType)
+	if prepared.Converted {
 		description += " [converted from HEIC]"
 	}
-	if resized {
+	if prepared.Resized {
 		description += " [resized to fit model limits]"
 	}
 
@@ -1105,51 +1074,20 @@ func (b *BrowseTools) readImageRun(ctx context.Context, input readImageInput) ll
 		},
 		{
 			Type:          llm.ContentTypeText,
-			MediaType:     mediaType,
+			MediaType:     prepared.MediaType,
 			Data:          base64Data,
-			DisplayWidth:  widthPx,
-			DisplayHeight: heightPx,
+			DisplayWidth:  prepared.Width,
+			DisplayHeight: prepared.Height,
 		},
 	}}
 }
 
-// prepareImageForModel fits imageData inside the limits advertised by the
-// llm.Service in ctx. Dimension overflow is fixed transparently by
-// downscaling so the user (and the model) don't have to care, since the
-// caller never asked for a specific size. Byte overflow that we can't fix
-// by downscaling produces an error so the agent can recompress or pick a
-// smaller source rather than having the API reject the whole request.
-//
-// Returns the (possibly resized) bytes, the resulting format, whether a
-// resize happened, and any error. source is included in error messages so
-// the agent knows what to fix. If no service is attached to ctx (e.g.
-// tests, ad-hoc callers) the data is returned unchanged.
-func prepareImageForModel(ctx context.Context, imageData []byte, detectedFormat, source string) (out []byte, format string, resized bool, err error) {
+func imageLimits(ctx context.Context) (maxDimension, maxBytes int) {
 	svc := llm.ServiceFromContext(ctx)
 	if svc == nil {
-		return imageData, detectedFormat, false, nil
+		return 0, 0
 	}
-
-	if maxDim := svc.MaxImageDimension(); maxDim > 0 {
-		// imageutil.ResizeImage no-ops when the image already fits and
-		// returns the original bytes (and format) unchanged. DecodeConfig
-		// failure (e.g. webp without a Go decoder) is treated as "can't
-		// resize"; we fall through to the byte-size check.
-		resizedData, resizedFormat, didResize, rerr := imageutil.ResizeImage(imageData, maxDim)
-		if rerr == nil {
-			imageData = resizedData
-			detectedFormat = resizedFormat
-			resized = didResize
-		}
-	}
-
-	if maxBytes := svc.MaxImageBytes(); maxBytes > 0 && len(imageData) > maxBytes {
-		return nil, "", false, fmt.Errorf(
-			"image too large for model: %s is %d bytes (after any auto-resize), model limit is %d bytes; recompress the image (e.g. lower JPEG quality) and try again",
-			source, len(imageData), maxBytes,
-		)
-	}
-	return imageData, detectedFormat, resized, nil
+	return svc.MaxImageDimension(), svc.MaxImageBytes()
 }
 
 // parseTimeout parses a timeout string and returns a time.Duration

--- a/claudetool/llm_one_shot.go
+++ b/claudetool/llm_one_shot.go
@@ -36,9 +36,13 @@ func (t *LLMOneShotTool) llmOneShotDescription() string {
 Unlike subagents, this is a single request/response with no conversation history or tools.
 Use this for simple LLM tasks like summarization, extraction, classification, reformatting,
 or image analysis with a vision-capable model.
+Use a subagent instead when the task requires tools, multiple steps, or iterative follow-up.
+Keep the request focused and ask for only the level of detail needed.
 
-The prompt is read from a UTF-8 text file (to handle large inputs cleanly).
-To send images, pass their paths in attachments; do not use an image as prompt_file.
+Pass short prompts directly in prompt. For large or generated prompts, use prompt_file.
+Exactly one of prompt or prompt_file is required; prompt_file must contain UTF-8 text.
+Attachments add image files to the request and require a vision-capable model.
+Do not use an image as prompt_file.
 Short results are returned inline; long results are written to a file.`
 
 	if len(t.AvailableModels) > 0 {
@@ -66,15 +70,18 @@ func (t *LLMOneShotTool) llmOneShotInputSchema() string {
 		modelProp = fmt.Sprintf(`,
     "model": {
       "type": "string",
-      "description": "LLM model to use. Defaults to the conversation's current model.",
+      "description": "LLM model to use. Select the model best suited to the request, considering the task's required capabilities and complexity. Defaults to the conversation's current model.",
       "enum": [%s]
     }`, strings.Join(enumItems, ", "))
 	}
 
 	return fmt.Sprintf(`{
   "type": "object",
-  "required": ["prompt_file"],
   "properties": {
+    "prompt": {
+      "type": "string",
+      "description": "Prompt text to send. Use prompt_file instead for large or generated prompts."
+    },
     "prompt_file": {
       "type": "string",
       "description": "Path to a file containing the prompt to send. Relative paths are resolved from the working directory."
@@ -97,7 +104,8 @@ func (t *LLMOneShotTool) llmOneShotInputSchema() string {
 }
 
 type llmOneShotInput struct {
-	PromptFile   string   `json:"prompt_file"`
+	Prompt       string   `json:"prompt,omitempty"`
+	PromptFile   string   `json:"prompt_file,omitempty"`
 	OutputFile   string   `json:"output_file,omitempty"`
 	Model        string   `json:"model,omitempty"`
 	SystemPrompt string   `json:"system_prompt,omitempty"`
@@ -115,30 +123,34 @@ func (t *LLMOneShotTool) Tool() *llm.Tool {
 }
 
 func (t *LLMOneShotTool) run(ctx context.Context, req llmOneShotInput) llm.ToolOut {
-	if req.PromptFile == "" {
-		return llm.ErrorfToolOut("prompt_file is required")
+	if req.Prompt == "" && req.PromptFile == "" {
+		return llm.ErrorfToolOut("exactly one of prompt or prompt_file is required")
+	}
+	if req.Prompt != "" && req.PromptFile != "" {
+		return llm.ErrorfToolOut("prompt and prompt_file are mutually exclusive")
 	}
 
-	// Resolve paths relative to working directory
 	wd := t.WorkingDir.Get()
-	promptPath := req.PromptFile
-	if !filepath.IsAbs(promptPath) {
-		promptPath = filepath.Join(wd, promptPath)
+	prompt := req.Prompt
+	if req.PromptFile != "" {
+		promptPath := req.PromptFile
+		if !filepath.IsAbs(promptPath) {
+			promptPath = filepath.Join(wd, promptPath)
+		}
+		promptBytes, err := os.ReadFile(promptPath)
+		if err != nil {
+			return llm.ErrorfToolOut("failed to read prompt file: %w", err)
+		}
+		if !utf8.Valid(promptBytes) || bytes.IndexByte(promptBytes, 0) >= 0 {
+			return llm.ErrorfToolOut("prompt_file must be a UTF-8 text file; pass image files in attachments")
+		}
+		prompt = string(promptBytes)
+		if strings.TrimSpace(prompt) == "" {
+			return llm.ErrorfToolOut("prompt file is empty")
+		}
+	} else if strings.TrimSpace(prompt) == "" {
+		return llm.ErrorfToolOut("prompt is empty")
 	}
-
-	// Read the prompt file
-	promptBytes, err := os.ReadFile(promptPath)
-	if err != nil {
-		return llm.ErrorfToolOut("failed to read prompt file: %w", err)
-	}
-	if !utf8.Valid(promptBytes) || bytes.IndexByte(promptBytes, 0) >= 0 {
-		return llm.ErrorfToolOut("prompt_file must be a UTF-8 text file; pass image files in attachments")
-	}
-	prompt := string(promptBytes)
-	if strings.TrimSpace(prompt) == "" {
-		return llm.ErrorfToolOut("prompt file is empty")
-	}
-
 	// Determine which model to use: explicit choice > conversation's model
 	modelID := t.ModelID
 	if req.Model != "" {

--- a/claudetool/llm_one_shot.go
+++ b/claudetool/llm_one_shot.go
@@ -1,13 +1,17 @@
 package claudetool
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"shelley.exe.dev/llm"
+	"shelley.exe.dev/llm/imageutil"
 )
 
 // LLMOneShotTool sends a one-shot prompt to an LLM and returns the result.
@@ -30,9 +34,11 @@ func (t *LLMOneShotTool) llmOneShotDescription() string {
 	base := `Send a one-shot prompt to an LLM and get a response.
 
 Unlike subagents, this is a single request/response with no conversation history or tools.
-Use this for simple LLM tasks like summarization, extraction, classification, or reformatting.
+Use this for simple LLM tasks like summarization, extraction, classification, reformatting,
+or image analysis with a vision-capable model.
 
-The prompt is read from a file (to handle large inputs cleanly).
+The prompt is read from a UTF-8 text file (to handle large inputs cleanly).
+To send images, pass their paths in attachments; do not use an image as prompt_file.
 Short results are returned inline; long results are written to a file.`
 
 	if len(t.AvailableModels) > 0 {
@@ -80,16 +86,22 @@ func (t *LLMOneShotTool) llmOneShotInputSchema() string {
     "system_prompt": {
       "type": "string",
       "description": "Optional system prompt to include."
+    },
+    "attachments": {
+      "type": "array",
+      "description": "Paths to image files to attach to the prompt. Relative paths are resolved from the working directory. The selected model must support images.",
+      "items": { "type": "string" }
     }%s
   }
 }`, modelProp)
 }
 
 type llmOneShotInput struct {
-	PromptFile   string `json:"prompt_file"`
-	OutputFile   string `json:"output_file,omitempty"`
-	Model        string `json:"model,omitempty"`
-	SystemPrompt string `json:"system_prompt,omitempty"`
+	PromptFile   string   `json:"prompt_file"`
+	OutputFile   string   `json:"output_file,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	SystemPrompt string   `json:"system_prompt,omitempty"`
+	Attachments  []string `json:"attachments,omitempty"`
 }
 
 // Tool returns an llm.Tool for the LLM one-shot functionality.
@@ -118,6 +130,9 @@ func (t *LLMOneShotTool) run(ctx context.Context, req llmOneShotInput) llm.ToolO
 	promptBytes, err := os.ReadFile(promptPath)
 	if err != nil {
 		return llm.ErrorfToolOut("failed to read prompt file: %w", err)
+	}
+	if !utf8.Valid(promptBytes) || bytes.IndexByte(promptBytes, 0) >= 0 {
+		return llm.ErrorfToolOut("prompt_file must be a UTF-8 text file; pass image files in attachments")
 	}
 	prompt := string(promptBytes)
 	if strings.TrimSpace(prompt) == "" {
@@ -157,12 +172,35 @@ func (t *LLMOneShotTool) run(ctx context.Context, req llmOneShotInput) llm.ToolO
 	if err != nil {
 		return llm.ErrorfToolOut("failed to get LLM service for model %q: %w", modelID, err)
 	}
+	if len(req.Attachments) > 0 && !svc.SupportsImages() {
+		return llm.ErrorfToolOut("model %q does not support image attachments", modelID)
+	}
 
 	// Build the request
+	message := llm.UserStringMessage(prompt)
+	for _, attachment := range req.Attachments {
+		path := attachment
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(wd, path)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return llm.ErrorfToolOut("failed to read attachment %q: %w", attachment, err)
+		}
+		prepared, err := imageutil.Prepare(data, path, svc.MaxImageDimension(), svc.MaxImageBytes())
+		if err != nil {
+			return llm.ErrorfToolOut("invalid attachment %q: %w", attachment, err)
+		}
+		message.Content = append(message.Content, llm.Content{
+			Type:          llm.ContentTypeText,
+			MediaType:     prepared.MediaType,
+			Data:          base64.StdEncoding.EncodeToString(prepared.Data),
+			DisplayWidth:  prepared.Width,
+			DisplayHeight: prepared.Height,
+		})
+	}
 	llmReq := &llm.Request{
-		Messages: []llm.Message{
-			llm.UserStringMessage(prompt),
-		},
+		Messages: []llm.Message{message},
 	}
 	if req.SystemPrompt != "" {
 		llmReq.System = []llm.SystemContent{{Text: req.SystemPrompt}}

--- a/claudetool/llm_one_shot_test.go
+++ b/claudetool/llm_one_shot_test.go
@@ -96,6 +96,61 @@ func TestLLMOneShotShortResult(t *testing.T) {
 	}
 }
 
+func TestLLMOneShotInlinePrompt(t *testing.T) {
+	dir := t.TempDir()
+	var capturedReq *llm.Request
+	provider := &oneShotMockProvider{
+		services: map[string]llm.Service{
+			"test-model": &oneShotMockService{
+				response: "4",
+				onDo: func(req *llm.Request) {
+					capturedReq = req
+				},
+			},
+		},
+	}
+	tool := &LLMOneShotTool{
+		LLMProvider: provider,
+		ModelID:     "test-model",
+		WorkingDir:  NewMutableWorkingDir(dir),
+	}
+
+	input, _ := json.Marshal(llmOneShotInput{Prompt: "What is 2+2?"})
+	result := tool.Tool().Run(context.Background(), input)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if capturedReq == nil || len(capturedReq.Messages) != 1 || len(capturedReq.Messages[0].Content) != 1 {
+		t.Fatalf("unexpected request: %#v", capturedReq)
+	}
+	if got := capturedReq.Messages[0].Content[0].Text; got != "What is 2+2?" {
+		t.Errorf("prompt = %q, want %q", got, "What is 2+2?")
+	}
+}
+
+func TestLLMOneShotPromptValidation(t *testing.T) {
+	tool := &LLMOneShotTool{WorkingDir: NewMutableWorkingDir(t.TempDir())}
+	tests := []struct {
+		name  string
+		input llmOneShotInput
+		want  string
+	}{
+		{name: "neither", want: "exactly one of prompt or prompt_file is required"},
+		{name: "both", input: llmOneShotInput{Prompt: "hello", PromptFile: "prompt.txt"}, want: "prompt and prompt_file are mutually exclusive"},
+		{name: "empty inline", input: llmOneShotInput{Prompt: "  \n"}, want: "prompt is empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := json.Marshal(tt.input)
+			result := tool.Tool().Run(context.Background(), input)
+			if result.Error == nil || !strings.Contains(result.Error.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", result.Error, tt.want)
+			}
+		})
+	}
+}
+
 func TestLLMOneShotLongResult(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("Generate a long story"), 0o644)
@@ -340,6 +395,7 @@ func TestLLMOneShotImageAttachments(t *testing.T) {
 	}
 	input, _ := json.Marshal(llmOneShotInput{
 		PromptFile:  "prompt.txt",
+		Model:       "vision",
 		Attachments: []string{"first.png", absolute},
 	})
 	result := tool.Tool().Run(context.Background(), input)
@@ -389,7 +445,7 @@ func TestLLMOneShotAttachmentErrors(t *testing.T) {
 				}},
 				ModelID: "vision", WorkingDir: NewMutableWorkingDir(dir),
 			}
-			input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.txt", Attachments: []string{tt.attachment}})
+			input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.txt", Model: "vision", Attachments: []string{tt.attachment}})
 			result := tool.Tool().Run(context.Background(), input)
 			if result.Error == nil || !strings.Contains(result.Error.Error(), tt.want) {
 				t.Fatalf("error = %v, want %q", result.Error, tt.want)
@@ -408,7 +464,7 @@ func TestLLMOneShotRejectsAttachmentsForNonImageModel(t *testing.T) {
 		}},
 		ModelID: "text", WorkingDir: NewMutableWorkingDir(dir),
 	}
-	input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.txt", Attachments: []string{"image.png"}})
+	input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.txt", Model: "text", Attachments: []string{"image.png"}})
 	result := tool.Tool().Run(context.Background(), input)
 	if result.Error == nil || !strings.Contains(result.Error.Error(), "does not support image attachments") {
 		t.Fatalf("unexpected error: %v", result.Error)
@@ -432,6 +488,15 @@ func TestLLMOneShotToolDescription(t *testing.T) {
 	}
 	if !strings.Contains(llmTool.Description, "- model-b (Model B (fancy))") {
 		t.Errorf("expected model-b with display name in description, got: %s", llmTool.Description)
+	}
+	if !strings.Contains(llmTool.Description, "Use a subagent instead") {
+		t.Errorf("expected subagent boundary, got: %s", llmTool.Description)
+	}
+	if !strings.Contains(llmTool.Description, "only the level of detail needed") {
+		t.Errorf("expected focused-response guidance, got: %s", llmTool.Description)
+	}
+	if !strings.Contains(llmTool.Description, "Attachments add image files") {
+		t.Errorf("expected attachment guidance, got: %s", llmTool.Description)
 	}
 }
 

--- a/claudetool/llm_one_shot_test.go
+++ b/claudetool/llm_one_shot_test.go
@@ -1,9 +1,12 @@
 package claudetool
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"image"
+	"image/png"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +38,10 @@ func (m *oneShotMockService) Provider() string        { return "" }
 func (m *oneShotMockService) TokenContextWindow() int { return 100000 }
 func (m *oneShotMockService) MaxImageDimension() int  { return 0 }
 func (m *oneShotMockService) MaxImageBytes() int      { return 0 }
+
+type noImageOneShotService struct{ oneShotMockService }
+
+func (m *noImageOneShotService) SupportsImages() bool { return false }
 
 // oneShotMockProvider implements LLMServiceProvider with configurable services.
 type oneShotMockProvider struct {
@@ -284,6 +291,127 @@ func TestLLMOneShotEmptyPrompt(t *testing.T) {
 	}
 	if !strings.Contains(result.Error.Error(), "prompt file is empty") {
 		t.Errorf("expected empty prompt error, got: %v", result.Error)
+	}
+}
+
+func TestLLMOneShotRejectsBinaryPrompt(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "prompt.png"), []byte{'P', 'N', 'G', 0, 0xff}, 0o644)
+	tool := &LLMOneShotTool{
+		LLMProvider: &oneShotMockProvider{services: map[string]llm.Service{
+			"test-model": &oneShotMockService{response: "unused"},
+		}},
+		ModelID:    "test-model",
+		WorkingDir: NewMutableWorkingDir(dir),
+	}
+
+	input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.png"})
+	result := tool.Tool().Run(context.Background(), input)
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "attachments") {
+		t.Fatalf("expected actionable binary prompt error, got %v", result.Error)
+	}
+}
+
+func writeOneShotPNG(t *testing.T, path string, width int) {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, image.NewNRGBA(image.Rect(0, 0, width, 2))); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLLMOneShotImageAttachments(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("Compare these images"), 0o644)
+	relative := filepath.Join(dir, "first.png")
+	absolute := filepath.Join(t.TempDir(), "second.png")
+	writeOneShotPNG(t, relative, 3)
+	writeOneShotPNG(t, absolute, 4)
+
+	var captured *llm.Request
+	svc := &oneShotMockService{response: "done", onDo: func(req *llm.Request) { captured = req }}
+	tool := &LLMOneShotTool{
+		LLMProvider: &oneShotMockProvider{services: map[string]llm.Service{"vision": svc}},
+		ModelID:     "vision",
+		WorkingDir:  NewMutableWorkingDir(dir),
+	}
+	input, _ := json.Marshal(llmOneShotInput{
+		PromptFile:  "prompt.txt",
+		Attachments: []string{"first.png", absolute},
+	})
+	result := tool.Tool().Run(context.Background(), input)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if captured == nil || len(captured.Messages) != 1 || len(captured.Messages[0].Content) != 3 {
+		t.Fatalf("unexpected request: %+v", captured)
+	}
+	contents := captured.Messages[0].Content
+	if contents[0].Text != "Compare these images" {
+		t.Errorf("prompt text = %q", contents[0].Text)
+	}
+	for i, width := range []int{3, 4} {
+		content := contents[i+1]
+		if content.MediaType != "image/png" || content.Data == "" {
+			t.Errorf("attachment %d = %+v", i, content)
+		}
+		if content.DisplayWidth != width || content.DisplayHeight != 2 {
+			t.Errorf("attachment %d dimensions = %dx%d", i, content.DisplayWidth, content.DisplayHeight)
+		}
+	}
+}
+
+func TestLLMOneShotAttachmentErrors(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("Describe it"), 0o644)
+	os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("not an image"), 0o644)
+	writeOneShotPNG(t, filepath.Join(dir, "truncated.png"), 10)
+	data, _ := os.ReadFile(filepath.Join(dir, "truncated.png"))
+	os.WriteFile(filepath.Join(dir, "truncated.png"), data[:len(data)/2], 0o644)
+
+	tests := []struct {
+		name       string
+		attachment string
+		want       string
+	}{
+		{name: "missing", attachment: "missing.png", want: "failed to read attachment"},
+		{name: "not image", attachment: "notes.txt", want: "file is not an image"},
+		{name: "corrupt", attachment: "truncated.png", want: "corrupt or truncated"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := &LLMOneShotTool{
+				LLMProvider: &oneShotMockProvider{services: map[string]llm.Service{
+					"vision": &oneShotMockService{response: "unused"},
+				}},
+				ModelID: "vision", WorkingDir: NewMutableWorkingDir(dir),
+			}
+			input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.txt", Attachments: []string{tt.attachment}})
+			result := tool.Tool().Run(context.Background(), input)
+			if result.Error == nil || !strings.Contains(result.Error.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", result.Error, tt.want)
+			}
+		})
+	}
+}
+
+func TestLLMOneShotRejectsAttachmentsForNonImageModel(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("Describe it"), 0o644)
+	writeOneShotPNG(t, filepath.Join(dir, "image.png"), 2)
+	tool := &LLMOneShotTool{
+		LLMProvider: &oneShotMockProvider{services: map[string]llm.Service{
+			"text": &noImageOneShotService{},
+		}},
+		ModelID: "text", WorkingDir: NewMutableWorkingDir(dir),
+	}
+	input, _ := json.Marshal(llmOneShotInput{PromptFile: "prompt.txt", Attachments: []string{"image.png"}})
+	result := tool.Tool().Run(context.Background(), input)
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "does not support image attachments") {
+		t.Fatalf("unexpected error: %v", result.Error)
 	}
 }
 

--- a/llm/imageutil/prepare.go
+++ b/llm/imageutil/prepare.go
@@ -1,0 +1,65 @@
+package imageutil
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Prepared contains image bytes ready to send to an LLM.
+type Prepared struct {
+	Data      []byte
+	MediaType string
+	Width     int
+	Height    int
+	Converted bool
+	Resized   bool
+}
+
+// Prepare validates image data and fits it within a model's advertised limits.
+func Prepare(data []byte, source string, maxDimension, maxBytes int) (Prepared, error) {
+	converted := false
+	if IsHEIC(data) {
+		var err error
+		data, err = ConvertHEICToPNG(data)
+		if err != nil {
+			return Prepared{}, fmt.Errorf("convert HEIC image %s: %w", source, err)
+		}
+		converted = true
+	}
+
+	mediaType := http.DetectContentType(data)
+	if !strings.HasPrefix(mediaType, "image/") {
+		return Prepared{}, fmt.Errorf("file is not an image: %s", mediaType)
+	}
+	if err := Validate(data); err != nil {
+		return Prepared{}, fmt.Errorf("image file appears corrupt or truncated (%s); re-upload or pick a different file: %w", source, err)
+	}
+
+	resized := false
+	format := strings.TrimPrefix(mediaType, "image/")
+	if maxDimension > 0 {
+		resizedData, resizedFormat, didResize, err := ResizeImage(data, maxDimension)
+		if err == nil {
+			data = resizedData
+			format = resizedFormat
+			resized = didResize
+		}
+	}
+	if maxBytes > 0 && len(data) > maxBytes {
+		return Prepared{}, fmt.Errorf(
+			"image too large for model: %s is %d bytes (after any auto-resize), model limit is %d bytes; recompress the image (e.g. lower JPEG quality) and try again",
+			source, len(data), maxBytes,
+		)
+	}
+
+	width, height, _ := DecodeDimensions(data)
+	return Prepared{
+		Data:      data,
+		MediaType: "image/" + format,
+		Width:     width,
+		Height:    height,
+		Converted: converted,
+		Resized:   resized,
+	}, nil
+}

--- a/llm/imageutil/prepare.go
+++ b/llm/imageutil/prepare.go
@@ -17,6 +17,17 @@ type Prepared struct {
 }
 
 // Prepare validates image data and fits it within a model's advertised limits.
+// HEIC is converted because Go's image package does not decode it directly.
+//
+// Recognized formats are fully decoded before being returned. Header sniffing
+// alone can accept a truncated upload; embedding those bytes can make the
+// provider reject the entire request and permanently wedge the conversation.
+//
+// Dimension overflow is fixed transparently by downscaling because callers do
+// not request a specific image size. Byte overflow that remains after resizing
+// is returned as an error so the caller can recompress or choose another image
+// instead of sending a request the provider will reject. source is included in
+// errors so the caller knows which input needs attention.
 func Prepare(data []byte, source string, maxDimension, maxBytes int) (Prepared, error) {
 	converted := false
 	if IsHEIC(data) {
@@ -39,6 +50,9 @@ func Prepare(data []byte, source string, maxDimension, maxBytes int) (Prepared, 
 	resized := false
 	format := strings.TrimPrefix(mediaType, "image/")
 	if maxDimension > 0 {
+		// ResizeImage returns the original bytes when the image already fits.
+		// If it cannot decode a format such as WebP, leave the bytes unchanged
+		// and continue to the byte-limit check.
 		resizedData, resizedFormat, didResize, err := ResizeImage(data, maxDimension)
 		if err == nil {
 			data = resizedData

--- a/llm/imageutil/prepare_test.go
+++ b/llm/imageutil/prepare_test.go
@@ -1,0 +1,56 @@
+package imageutil
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrepare(t *testing.T) {
+	data := createTestPNG(t, 300, 100)
+	prepared, err := Prepare(data, "large.png", 200, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.MediaType != "image/png" || !prepared.Resized {
+		t.Fatalf("prepared = %+v", prepared)
+	}
+	if prepared.Width != 200 || prepared.Height != 66 {
+		t.Errorf("dimensions = %dx%d, want 200x66", prepared.Width, prepared.Height)
+	}
+
+	unchanged, err := Prepare(createTestPNG(t, 10, 8), "small.png", 200, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.Resized || unchanged.Width != 10 || unchanged.Height != 8 {
+		t.Errorf("unchanged = %+v", unchanged)
+	}
+}
+
+func TestPrepareErrors(t *testing.T) {
+	if _, err := Prepare([]byte("plain text"), "notes.txt", 0, 0); err == nil || !strings.Contains(err.Error(), "not an image") {
+		t.Fatalf("non-image error = %v", err)
+	}
+
+	data := createTestPNG(t, 64, 64)
+	if _, err := Prepare(data[:len(data)/2], "broken.png", 0, 0); err == nil || !strings.Contains(err.Error(), "corrupt or truncated") {
+		t.Fatalf("corrupt image error = %v", err)
+	}
+
+	data = createTestPNG(t, 10, 10)
+	if _, err := Prepare(data, "large.png", 0, len(data)-1); err == nil || !strings.Contains(err.Error(), "image too large") {
+		t.Fatalf("byte limit error = %v", err)
+	}
+}
+
+func TestPreparePreservesBytesWithoutLimits(t *testing.T) {
+	data := createTestPNG(t, 12, 9)
+	prepared, err := Prepare(data, "image.png", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(prepared.Data, data) {
+		t.Error("Prepare changed an image that needed no conversion or resize")
+	}
+}

--- a/loop/predictable.go
+++ b/loop/predictable.go
@@ -971,7 +971,11 @@ func (s *PredictableService) makeToolSmorgasbordResponse(inputTokens uint64) *ll
 	})
 
 	// llm_one_shot tool
-	llmInput, _ := json.Marshal(map[string]string{"prompt_file": "/tmp/test-prompt.txt"})
+	llmInput, _ := json.Marshal(map[string]any{
+		"prompt":      "Describe the attached image briefly.",
+		"model":       "vision-model",
+		"attachments": []string{"/tmp/test-image.png"},
+	})
 	content = append(content, llm.Content{
 		ID:        fmt.Sprintf("tool_llm_%d", (baseNano+13)%1000),
 		Type:      llm.ContentTypeToolUse,

--- a/ui/src/vue/components/tools/LLMOneShotTool.vue
+++ b/ui/src/vue/components/tools/LLMOneShotTool.vue
@@ -49,6 +49,11 @@
         <pre class="tool-code">{{ model }}</pre>
       </div>
 
+      <div v-if="input.attachments?.length" class="tool-section">
+        <div class="tool-label">Attachments:</div>
+        <pre class="tool-code">{{ input.attachments.join("\n") }}</pre>
+      </div>
+
       <div v-if="input.system_prompt" class="tool-section">
         <div class="tool-label">System prompt:</div>
         <pre class="tool-code">{{ input.system_prompt }}</pre>
@@ -80,6 +85,7 @@ interface LLMOneShotInput {
   output_file?: string;
   model?: string;
   system_prompt?: string;
+  attachments?: string[];
 }
 
 const props = defineProps<{
@@ -115,6 +121,9 @@ const summary = computed(() => {
   const parts: string[] = [];
   if (promptFile.value) parts.push(promptFile.value);
   if (model.value) parts.push(`model: ${model.value}`);
+  if (input.value.attachments?.length) {
+    parts.push(`${input.value.attachments.length} image attachment${input.value.attachments.length === 1 ? "" : "s"}`);
+  }
   return parts.join(" · ") || "llm_one_shot";
 });
 </script>

--- a/ui/src/vue/components/tools/LLMOneShotTool.vue
+++ b/ui/src/vue/components/tools/LLMOneShotTool.vue
@@ -39,9 +39,14 @@
     </div>
 
     <div v-if="isExpanded" class="tool-details">
-      <div class="tool-section">
+      <div v-if="prompt" class="tool-section">
+        <div class="tool-label">Prompt:</div>
+        <pre class="tool-code">{{ prompt }}</pre>
+      </div>
+
+      <div v-if="promptFile" class="tool-section">
         <div class="tool-label">Prompt file:</div>
-        <pre class="tool-code">{{ promptFile || "(none)" }}</pre>
+        <pre class="tool-code">{{ promptFile }}</pre>
       </div>
 
       <div v-if="model" class="tool-section">
@@ -81,6 +86,7 @@ import type { LLMContent } from "../../../types";
 import { useToolExpanded } from "../../composables/toolDetail";
 
 interface LLMOneShotInput {
+  prompt?: string;
   prompt_file?: string;
   output_file?: string;
   model?: string;
@@ -104,6 +110,7 @@ const input = computed<LLMOneShotInput>(() =>
     : {},
 );
 
+const prompt = computed(() => input.value.prompt || "");
 const promptFile = computed(() => input.value.prompt_file || "");
 const model = computed(() => input.value.model || "");
 
@@ -119,7 +126,8 @@ const isComplete = computed(() => !props.isRunning && props.toolResult !== undef
 
 const summary = computed(() => {
   const parts: string[] = [];
-  if (promptFile.value) parts.push(promptFile.value);
+  if (prompt.value) parts.push(prompt.value.length > 80 ? `${prompt.value.slice(0, 77)}...` : prompt.value);
+  else if (promptFile.value) parts.push(promptFile.value);
   if (model.value) parts.push(`model: ${model.value}`);
   if (input.value.attachments?.length) {
     parts.push(`${input.value.attachments.length} image attachment${input.value.attachments.length === 1 ? "" : "s"}`);


### PR DESCRIPTION
## Summary

Reference: [Discord discussion](https://discord.com/channels/1405685085923049482/1450334528210993295/1527040635385942037)

Add first-class image attachments to `llm_one_shot`.

When GLM 5.2 encountered a screenshot it could not inspect, it already attempted to delegate the task through `llm_one_shot`. 

<details><summary>Example GLM 5.2 Interaction</summary>
<kbd>
# xkcd-screenshot-analysis

**Model:** glm-5.2-fireworks  
**Directory:** /home/exedev  
**Started:** 2026/07/16, 13:48:54  
**Exported:** 2026/07/16, 20:05:14

## User

what's in todays xkcd? take a screenshot and analyze the screenshot not the html

## Assistant

<details><summary>💭 Thinking</summary>

The user wants me to check today's xkcd comic, take a screenshot, and analyze the screenshot rather than the HTML. Let me navigate to xkcd.com and take a screenshot.

</details>

**🛠️ Tool: `browser`**

```json
{
  "action": "navigate",
  "url": "https://xkcd.com/"
}
```

<details><summary>Result</summary>

```
done
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

Let me take a screenshot of today's xkcd comic.

</details>

**🛠️ Tool: `browser`**

```json
{
  "action": "screenshot"
}
```

<details><summary>Result</summary>

```
Screenshot taken (saved as /tmp/shelley-screenshots/68d7f19e-898d-4bc9-b982-3f8bc8f396c1.png)
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

Let me view the screenshot.

</details>

**🛠️ Tool: `bash`**

```json
{
  "command": "ls -la /tmp/shelley-screenshots/68d7f19e-898d-4bc9-b982-3f8bc8f396c1.png"
}
```

<details><summary>Result</summary>

```
-rw-r--r-- 1 exedev exedev 124258 Jul 16 04:49 /tmp/shelley-screenshots/68d7f19e-898d-4bc9-b982-3f8bc8f396c1.png

```

</details>

## Assistant

**🛠️ Tool: `llm_one_shot`**

```json
{
  "prompt_file": "/tmp/shelley-screenshots/68d7f19e-898d-4bc9-b982-3f8bc8f396c1.png",
  "model": "gpt-5.4"
}
```

<details><summary>Result</summary>

```
It looks like you pasted raw PNG binary data (`PNG ... IHDR ... IDAT ... IEND`), not a normal text question.

If you want help with the image, you can:

- upload the PNG as an image/file
- tell me what you want to do with it, e.g.:
  - describe the image
  - extract text (OCR)
  - identify objects
  - debug PNG/file issues
  - convert or parse the binary

If you want, I can also help you recognize or decode the PNG structure from the bytes you pasted.

---
model: gpt-5.4, input_tokens: 94278, output_tokens: 227
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

The llm_one_shot reads a file as a prompt. But it's treating the PNG as text, not as an image. I need a way to actually analyze an image. Let me write a prompt file that references the image, but the tool reads the file content as the prompt text.

Actually, the issue is that llm_one_shot reads the prompt_file as text. To analyze an image, I'd need to pass it as an image attachment, which this tool may not support directly.

Let me think about alternatives. I could use the browser to display the image and... no.

Actually, maybe I should use a subagent that can use the browser tool and take screenshots, but the subagent can't "see" the screenshot either — it just gets a file path.

The best approach: I can take the screenshot (done), and I need to actually look at it myself. As an LLM with vision, I should be able to see images that are returned to me. The browser screenshot tool returns a file path, but does the image content come back to my context?

Looking at the tool, the screenshot action just returns "Screenshot taken (saved as ...)". The image is not inline in my context. So I can't directly see it.

Let me think about what tools allow me to analyze an image. The llm_one_shot tool reads a prompt_file. If I write a prompt that somehow includes the image... but it reads it as text.

Hmm, maybe I can encode the image as base64 and include it in a prompt file with a data URI? Some LLM APIs support image input via markdown image syntax or data URIs. Let me try creating a prompt file that references the image as a data URI or a file path that the model can read.

Actually, the most reliable approach: write a prompt file with the image embedded as a base64 data URI in markdown format `![image](data:image/png;base64,...)`. Many chat completions APIs with vision support this. Let me try.

Let me create a script that builds such a prompt file.

</details>

The `llm_one_shot` tool treated the PNG bytes as text. I need to embed the image into a prompt file as a base64 data URI so the vision model actually sees it.

**🛠️ Tool: `bash`**

```json
{
  "command": "cd /tmp && python3 - <<'PY'\nimport base64, json\nimg = \"/tmp/shelley-screenshots/68d7f19e-898d-4bc9-b982-3f8bc8f396c1.png\"\nwith open(img,\"rb\") as f:\n    b64 = base64.b64encode(f.read()).decode()\n\nprompt = (\n    \"This is a screenshot of today's xkcd.com homepage. \"\n    \"Please analyze the *image itself* (the comic drawing and any text in it) and tell me:\\n\"\n    \"1. The comic number and title (hover/title text if visible).\\n\"\n    \"2. A description of what is drawn.\\n\"\n    \"3. The joke/punchline and what makes it funny.\\n\"\n    \"4. Any alt-text / tooltip text you can read in the image.\\n\\n\"\n    f\"![xkcd screenshot](data:image/png;base64,{b64})\\n\"\n)\nwith open(\"/tmp/xkcd_prompt.txt\",\"w\") as f:\n    f.write(prompt)\nprint(\"wrote\", len(prompt), \"chars\")\nPY"
}
```

<details><summary>Result</summary>

```
[shelley hint: this command chained `cd <path>` with another command. `cd` inside a bash invocation does not persist across tool calls. Prefer calling the change_dir tool once, then running subsequent commands directly.]

wrote 166062 chars

```

</details>

## Assistant

**🛠️ Tool: `llm_one_shot`**

```json
{
  "model": "gpt-5.4",
  "prompt_file": "/tmp/xkcd_prompt.txt"
}
```

<details><summary>Result (error)</summary>

```
Tool execution cancelled by user
```

</details>

## Assistant

[Operation cancelled]

## User

use llm one shot with attachments

## Assistant

<details><summary>💭 Thinking</summary>

The user is telling me to use llm_one_shot with attachments. But looking at the tool definition for llm_one_shot, I only see parameters: prompt_file, output_file, system_prompt, model. There's no "attachments" parameter listed.

Wait, maybe the prompt_file can reference attachments, or maybe there's a way to pass attachments. Let me re-read the tool spec.

The llm_one_shot tool has:
- prompt_file (required)
- output_file
- system_prompt
- model

No attachments parameter. Hmm. But the user says "use llm one shot with attachments". Maybe the prompt_file format supports attachments — like maybe if I write a prompt file that references an image file path, it gets attached?

Actually, maybe the shelley CLI supports attachments. Let me check the shelley CLI help to see if there's an attachments option for llm-one-shot.

Let me check the actual CLI.

</details>

**🛠️ Tool: `bash`**

```json
{
  "command": "shelley llm-one-shot --help 2>&1 | head -60"
}
```

<details><summary>Result</summary>

```
Unknown command: llm-one-shot
Usage: shelley [global-flags] <command> [command-flags]

Global flags:
  -config string
    	Path to shelley.json configuration file (optional)
  -db string
    	Path to SQLite database file (default "shelley.db")
  -debug
    	Enable debug logging
  -default-model string
    	Default model for web UI (default "claude-opus-4.8")
  -disable-gateway
    	Ignore llm_gateway from shelley.json
  -disable-llm-integration
    	Ignore any discovered exe.dev llm integration
  -model string
    	LLM model to use (use 'predictable' for testing) (default "claude-opus-4.8")
  -predictable-only
    	Use only the predictable service, ignoring all other models

Commands:
  serve [flags]                 Start the web server
  models [flags]                List the models the server would expose, without starting it
  client [flags] <subcommand>   CLI client (chat, read, list, archive) (experimental)
  skill <cat|ls|new> [name]     Read, list, or create skills
  dtach <new|attach> ...        Persistent PTY sessions over a Unix socket
  unpack-template <name> <dir>  Unpack a project template to a directory
  version                       Print version information as JSON

Use 'shelley <command> -h' for command-specific help

```

</details>

## Assistant

**🛠️ Tool: `bash`**

```json
{
  "command": "shelley client chat --help 2>&1 | head -80"
}
```

<details><summary>Result</summary>

```
Usage of client chat:
  -c string
    	Conversation ID to continue (creates new if omitted)
  -cwd string
    	Working directory for the conversation
  -disable-notifications
    	Disable end-of-turn notifications for this conversation (new conversations only)
  -ephemeral
    	Wait for end of turn, then archive the conversation (for cron-style cleanup)
  -model string
    	Model to use (server default if empty)
  -p string
    	Message to send (required)

```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

The `llm_one_shot` tool doesn't have an attachments parameter in the schema I was given. But the user says "use llm one shot with attachments". Let me re-read the tool schema...

Looking at the llm_one_shot schema:
- prompt_file (required)
- output_file
- system_prompt
- model

There's no "attachments" parameter listed. But the user is telling me to use it. Maybe the prompt_file format supports attachments somehow? Let me think about this differently.

Perhaps the shelley client chat supports attachments via some flag I haven't found, or maybe the llm_one_shot tool reads the prompt file and if it contains references to files... Actually, maybe there's a way to pass images as attachments in the prompt file format.

Wait, let me re-read. The user said "use llm one shot with attachments". Maybe the tool actually does support an attachments mechanism that I'm not seeing in the schema. Let me check if maybe I can pass the image path some other way.

Actually, looking more carefully - maybe the prompt file can reference attachment files. Or perhaps there's a JSON format for the prompt file that includes attachments. Let me try a JSON-formatted prompt file that references the image as an attachment.

Let me look at how shelley handles prompts - maybe the prompt_file can be a structured format. Let me check the shelley docs or source.

Actually, the most reliable approach: the llm_one_shot tool reads a prompt from a file. Perhaps if I write the prompt file with a special syntax referencing an attachment file, it will attach it. But I don't know the syntax.

Let me check if there's documentation about llm one shot attachments.

</details>

**🛠️ Tool: `bash`**

```json
{
  "command": "find / -path /proc -prune -o -name \"*.md\" -print 2>/dev/null | xargs grep -l \"llm-one-shot\\|llm_one_shot\\|one.shot\" 2>/dev/null | grep -v proc | head; echo \"---\"; shelley skill ls 2>&1 | head"
}
```

<details><summary>Result</summary>

```
/usr/share/go-1.22/src/runtime/HACKING.md
/usr/share/doc/nodejs/api/crypto.md
/usr/share/doc/nodejs/changelogs/CHANGELOG_V21.md
/usr/share/doc/nodejs/changelogs/CHANGELOG_V16.md
/usr/share/doc/nodejs/changelogs/CHANGELOG_V20.md
/home/exedev/go/pkg/mod/modernc.org/sqlite@v1.53.0/CHANGELOG.md
/home/exedev/go/pkg/mod/sketch.dev@v0.0.33/test_recipes/README.md
/home/exedev/go/pkg/mod/sketch.dev@v0.0.33/test_recipes/dear_llm.md
/home/exedev/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/HACKING.md
/home/exedev/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/runtime/HACKING.md
---
clojure-eval	Evaluate Clojure code via nREPL using clj-nrepl-eval. Use this when you need to test code, check if edited files compile, verify function behavior, or interact with a running REPL session.
excalidraw	Use when the user asks for a diagram, sketch, flowchart, architecture diagram, sequence diagram, mind map, or other visual explanation. Renders hand-drawn-style diagrams from Excalidraw JSON via the output_iframe tool.
node-and-js-frameworks	Use when the user needs Node.js or npm installed, or is running a JS framework dev server (Next.js, Vite, webpack, etc.) on an exe.dev VM — especially if the browser logs 'WebSocket ... failed', or the dev server complains about cross-origin requests, allowedDevOrigins, or allowedHosts.
previous-conversations	Use when the user references a previous conversation, asks you to continue earlier work, or you need to look up what was discussed before.
reflection-integration	[when: exe.dev] Use to discover external services and APIs available on this exe.dev VM via network-edge-injected credentials and to discover VM metadata like owner email, VM tags, and default port.
schedule	Use when a user requests a task to be done later or on a schedule.
shelley-hooks	Use when the user wants to customize Shelley by injecting behavior at lifecycle events. It documents Shelley's hooks.

```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

The user says "use llm one shot with attachments". The `llm_one_shot` tool reads a prompt from a file. The question is how to pass an image as an attachment. Let me check the tool more carefully — the schema says `prompt_file` is required and `output_file` is optional. There's no explicit attachments parameter in the schema I was given.

But the user insists there's a way to use attachments. Maybe the prompt file can contain some special markup for attachments, or maybe I should look at how the tool is implemented. Let me search for how llm_one_shot handles files.

Actually, the hint might be that the prompt file can reference attachments. Let me look at the shelley source or docs to understand how attachments work with llm_one_shot.

Let me search the shelley binary or any config.

</details>

**🛠️ Tool: `bash`**

```json
{
  "command": "which shelley; file $(which shelley); shelley version 2>&1 | head"
}
```

<details><summary>Result</summary>

```
/usr/local/bin/shelley
/usr/local/bin/shelley: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=pbhwAoYSUL7mR6cGU35P/pJh_MVJKXup23qFqbx0U/nZTu_yD-c0JqISbnORPK/7PjnfeY1R5tNKst-YPPL, BuildID[sha1]=3192cb3052d89c9857c30d4afff885337649f63b, stripped
{
  "version": "0.800.934456644",
  "tag": "v0.800.934456644",
  "commit": "725da4a8e443c300f3543ff27efaccdee374381c",
  "commit_time": "2026-07-16T00:26:59Z"
}

```
</kbd>
</details>

## Assistant

[Operation cancelled]


</details> 


However, `llm_one_shot` only accepts `prompt_file` which GLM attempted to supply with the screenshot path. 

Shelley then treated the PNG as prompt text and sent its raw bytes to the delegated model.

This PR makes the workflow GLM was already attempting valid

## Changes

### Share image preparation

- Adds one reusable image-preparation helper covering validation, HEIC conversion, resizing, MIME detection, dimensions, and model byte limits.

- The browser screenshot and read_image paths now use the same helper, preserving their behavior while removing duplicate image-processing code.

### Add one-shot image attachments
- Adds an image-only attachments input to llm_one_shot.
- Attachment paths resolve relative to the conversation working directory and are added, in order, to the outgoing request using Shelley’s existing provider-neutral multimodal content representation.
- The selected model must support images. Invalid, missing, corrupt, or oversized attachments fail before the delegated request is sent.
prompt_file is now validated as UTF-8 text so image files cannot accidentally be interpreted as prompts.

### Add inline one-shot prompts
- Adds prompt as an alternative to prompt_file, avoiding a temporary file for short requests such as image description.
- Exactly one of prompt or prompt_file is accepted. Existing file-backed and text-only calls otherwise retain their behavior.
- The existing tool card displays inline prompts and attachment paths, and the predictable fixture exercises the new input shape.

## Example Interactions with this branch applied

<details><summary>RandomImageGenerator investigation </summary>
<kbd>
# randompicturegenerator-image-description-1

**Model:** glm-5.2-fireworks  
**Directory:** /home/exedev/shelley  
**Started:** 2026/07/16, 19:45:14  
**Exported:** 2026/07/16, 20:19:40

## User

what picture is displayed on https://randompicturegenerator.com/
do not trust html, describe the image

## Assistant

<details><summary>💭 Thinking</summary>

The user wants me to go to https://randompicturegenerator.com/ and describe the picture that is displayed. They specifically say not to trust HTML and to describe the image. This means I need to actually look at the rendered image, not just the HTML/alt text.

Let me navigate to the site and take a screenshot to see what's actually displayed.

</details>

I'll navigate to the site and capture what's actually displayed.

**🛠️ Tool: `browser`**

```json
{
  "action": "navigate",
  "url": "https://randompicturegenerator.com/"
}
```

<details><summary>Result</summary>

```
done
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

Let me take a screenshot to see what's displayed.

</details>

**🛠️ Tool: `browser`**

```json
{
  "action": "screenshot"
}
```

<details><summary>Result</summary>

```
Screenshot taken (saved as /tmp/shelley-screenshots/1f44cec2-6cd6-4994-8743-05694302e7d8.png)
```

</details>

## Assistant

I can't directly view the screenshot. Let me capture the image and analyze it.

**🛠️ Tool: `bash`**

```json
{
  "command": "ls -la /tmp/shelley-screenshots/1f44cec2-6cd6-4994-8743-05694302e7d8.png"
}
```

<details><summary>Result</summary>

```
-rw-r--r-- 1 exedev exedev 196809 Jul 16 10:45 /tmp/shelley-screenshots/1f44cec2-6cd6-4994-8743-05694302e7d8.png

```

</details>

## Assistant

The screenshot is the whole page, but I need the actual image being displayed. Let me find the image element on the page and capture it directly.

**🛠️ Tool: `browser`**

```json
{
  "action": "eval",
  "expression": "\n(() => {\n  const imgs = Array.from(document.images).map((i, n) => ({\n    n,\n    src: i.currentSrc || i.src,\n    alt: i.alt,\n    w: i.naturalWidth,\n    h: i.naturalHeight,\n  }));\n  return JSON.stringify(imgs, null, 2);\n})()\n"
}
```

<details><summary>Result</summary>

```
JavaScript result (1310 bytes) written to: /tmp/shelley-console-logs/js_result_19c0fcf1.json
Use `cat /tmp/shelley-console-logs/js_result_19c0fcf1.json` to view the full content.
```

</details>

## Assistant

**🛠️ Tool: `bash`**

```json
{
  "command": "cat /tmp/shelley-console-logs/js_result_19c0fcf1.json"
}
```

<details><summary>Result</summary>

```
"[\n  {\n    \"n\": 0,\n    \"src\": \"https://randompicturegenerator.com/img/picture-generator/50e7d6454355b10ff3d8992cc12c30771037dbf85254794e702673dd9e4b_640.jpg\",\n    \"alt\": \"suit, business man, business\",\n    \"w\": 640,\n    \"h\": 426\n  },\n  {\n    \"n\": 1,\n    \"src\": \"https://randompicturegenerator.com/\",\n    \"alt\": \"\",\n    \"w\": 0,\n    \"h\": 0\n  },\n  {\n    \"n\": 2,\n    \"src\": \"https://randompicturegenerator.com/img/cat-generator/g3773e595a8ef5a3349ff896ac0b42959bd4c1f7136715552cabc8b9f1c2d42add537ace78a88b27b6fa6123c7f76eaa0_640.jpg\",\n    \"alt\": \"Random Cat Pictures\",\n    \"w\": 0,\n    \"h\": 0\n  },\n  {\n    \"n\": 3,\n    \"src\": \"https://randompicturegenerator.com/img/dog-generator/g5d33df79829d9cfbba39903471d1cd1bc2d6cdd243e222607e337d5575cb76ed10582deda8ed10bb0d1c3c43a6494f5a_640.jpg\",\n    \"alt\": \"Random Dog Pictures\",\n    \"w\": 0,\n    \"h\": 0\n  },\n  {\n    \"n\": 4,\n    \"src\": \"https://randompicturegenerator.com/img/sunset-generator/sunset_3793717.jpg\",\n    \"alt\": \"Random Sunset Pictures\",\n    \"w\": 0,\n    \"h\": 0\n  },\n  {\n    \"n\": 5,\n    \"src\": \"https://randompicturegenerator.com/img/ocean-generator/ocean_2444040.jpg\",\n    \"alt\": \"Random Ocean Pictures\",\n    \"w\": 0,\n    \"h\": 0\n  }\n]"
```

</details>

## Assistant

I need the actual image, not just the alt text. Let me download the main displayed image and analyze it with a vision-capable model.

**🛠️ Tool: `bash`**

```json
{
  "command": "curl -sL \"https://randompicturegenerator.com/img/picture-generator/50e7d6454355b10ff3d8992cc12c30771037dbf85254794e702673dd9e4b_640.jpg\" -o /tmp/main_pic.jpg && file /tmp/main_pic.jpg && ls -la /tmp/main_pic.jpg"
}
```

<details><summary>Result</summary>

```
/tmp/main_pic.jpg: JPEG image data, JFIF standard 1.01, aspect ratio, density 1x1, segment length 16, progressive, precision 8, 640x426, components 3
-rw-r--r-- 1 exedev exedev 27831 Jul 16 10:45 /tmp/main_pic.jpg

```

</details>

## Assistant

**🛠️ Tool: `llm_one_shot`**

```json
{
  "prompt": "Describe in detail what is depicted in this image. Ignore any text/captions; describe only the visual contents of the photo: subjects, people, objects, setting, colors, composition, mood. Be specific.",
  "attachments": [
    "/tmp/main_pic.jpg"
  ],
  "model": "claude-opus-4.8"
}
```

<details><summary>Result</summary>

```
# Image Description

This is a humorous studio portrait featuring a man in a dynamic, playful pose against a plain light gray background.

## The Subject
The man appears to be middle-aged with shoulder-length, tousled gray/silver hair. He has a dramatic, exaggerated facial expression—teeth clenched and bared in an aggressive or intense grimace, with wide, focused eyes that convey mock ferocity.

## Pose and Action
He is captured in a crouched, action-oriented stance, leaning to his right side as if in the middle of a spy or action-movie maneuver. His body is angled dynamically, suggesting movement and tension.

## The Comedic Element
The central joke of the image is that he is holding a **ripe yellow banana** and pointing it forward like a handgun, aiming it toward the camera/viewer. His hand grips it in a distinct "shooting" position, with the banana extended prominently in the foreground. The banana has some natural brown speckles and spots on its peel.

## Clothing
He wears a well-tailored **light gray business suit** with a matching vest, a crisp white dress shirt, and a **dark navy blue tie**. The professional attire contrasts comically with his ridiculous "weapon" and wild expression.

## Composition and Mood
- The banana and his outstretched arm dominate the left-center portion of the frame due to the forced perspective.
- The lighting is soft and even, typical of studio photography.
- The overall mood is **comedic, absurd, and lighthearted**, playing on the contrast between his serious business appearance/intense expression and the silly fruit prop.

The image likely serves as a conceptual stock photo, possibly relating to themes of business aggression, harmless threats, or workplace humor.

---
model: claude-opus-4.8, input_tokens: 441, output_tokens: 576
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

I described the image directly from the actual JPEG bytes, not from HTML/alt text. Let me give the user the answer.

</details>

I grabbed the actual image bytes (not the alt text) and analyzed them. Here's what's displayed:

A humorous studio portrait of a middle-aged man with shoulder-length tousled gray/silver hair, wearing a well-tailored light gray business suit with matching vest, white shirt, and a dark navy blue tie. He's in a crouched, action-movie stance leaning to one side, with an exaggerated intense grimace — teeth bared, eyes wide. The comedic gag: he's holding a **ripe yellow banana** in a pistol-grip and aiming it at the camera like a handgun. Soft even studio lighting against a plain light gray background. The mood is absurd/comedic — the contrast between his sharp business attire/fierce expression and the silly fruit "weapon."

(For reference, the page's alt text only said "suit, business man, business" — it didn't mention the banana at all, so trusting the HTML would have missed the whole point of the picture.)

</kbd>
</details> 

<details><summary>XKCD Visual Check</summary>
<kbd>
# xkcd-screenshot-analysis

**Model:** glm-5.2-fireworks  
**Directory:** /home/exedev/shelley  
**Started:** 2026/07/16, 20:19:13  
**Exported:** 2026/07/16, 20:25:32

## User

what's in todays xkcd? take a screenshot and analyze the screenshot not the html

## Assistant

<details><summary>💭 Thinking</summary>

The user wants to know what's in today's xkcd comic. They want me to take a screenshot and analyze the screenshot, not the HTML. Let me navigate to xkcd.com and take a screenshot, then analyze it.

Let me navigate to xkcd.com first.

</details>

**🛠️ Tool: `browser`**

```json
{
  "action": "navigate",
  "url": "https://xkcd.com/"
}
```

<details><summary>Result</summary>

```
done
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

Let me take a screenshot of the page and analyze it.

</details>

**🛠️ Tool: `browser`**

```json
{
  "action": "screenshot"
}
```

<details><summary>Result</summary>

```
Screenshot taken (saved as /tmp/shelley-screenshots/f4275098-2c21-49d6-9919-de831e78317f.png)
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

Let me look at the screenshot to analyze it. I'll use the llm_one_shot tool with the image attachment.

</details>

**🛠️ Tool: `llm_one_shot`**

```json
{
  "prompt": "Analyze this screenshot of today's xkcd comic. Describe what you see in the comic panels, any text or dialogue, and the title text/alt text if visible. Be detailed.",
  "attachments": [
    "/tmp/shelley-screenshots/f4275098-2c21-49d6-9919-de831e78317f.png"
  ]
}
```

<details><summary>Result (error)</summary>

```
model "glm-5.2-fireworks" does not support image attachments
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

The default model doesn't support images. Let me use a vision-capable model.

</details>

**🛠️ Tool: `llm_one_shot`**

```json
{
  "prompt": "Analyze this screenshot of today's xkcd comic. Describe what you see in the comic panels, any text or dialogue, and the title text/alt text if visible. Be detailed.",
  "attachments": [
    "/tmp/shelley-screenshots/f4275098-2c21-49d6-9919-de831e78317f.png"
  ],
  "model": "claude-opus-4.8"
}
```

<details><summary>Result</summary>

```
# XKCD Comic Analysis: "Time Change"

## Page Layout

This is a screenshot of the XKCD website displaying comic #3272, titled **"Time Change"**.

### Header Elements
- **Left sidebar navigation** includes: Archive, What If?, About, Feed·Email, TW·FB·IG, -Books-, What If? 2, WI?·TE·HT
- **XKCD logo** with tagline: "A webcomic of romance, sarcasm, math, and language."
- Note that "XKCD updates every Monday, Wednesday, and Friday."
- Navigation buttons appear above and below the comic: |<, < Prev, Random, Next >, >|

## Comic Content

The comic consists of **three panels** in the classic XKCD black-and-white stick figure style.

### Panel 1
A stick figure stands at a podium/lectern giving a presentation. 
- **Dialogue:** "WE ALL HATE SPRINGING FORWARD, BUT WE LOVE FALLING BACK."

### Panel 2
The same figure at the podium, now with a small audience of stick figures visible in the foreground (facing away from the viewer).
- **Dialogue:** "THEREFORE, WE ARE ABOLISHING THE SPRING TIME CHANGE **ONLY**. WE'LL GAIN AN HOUR EVERY YEAR, BUT NEVER LOSE ONE."

### Panel 3
Close-up of a stick figure (audience member) who has raised their hand/arm to ask a question, with the presenter's speech coming from off-panel.
- **Audience question (bottom left):** "WON'T THAT CAUSE THE CLOCKS TO SPIRAL OUT OF SYNC WITH THE SUN?"
- **Presenter's response:** "THEN WE WILL MEET THE CHAOS CLEAR-EYED AND WELL-RESTED!"

## Footer Information
- **Permanent link:** https://xkcd.com/3272/
- **Image URL:** https://imgs.xkcd.com/comics/time_change.png

## Notes
The **title text/alt text** (which appears when hovering over the comic image) is **not visible** in this screenshot, as it typically only appears on mouse hover.

## Humor Explanation
The comic satirizes the perennial debate over Daylight Saving Time. The joke plays on the fact that people generally enjoy "falling back" (gaining an hour of sleep) but dislike "springing forward" (losing an hour). The absurd proposed solution—keeping only the fall time change—would cause clocks to progressively drift out of alignment with the actual solar day, embracing chaos in exchange for being perpetually well-rested.

---
model: claude-opus-4.8, input_tokens: 1263, output_tokens: 917
```

</details>

## Assistant

<details><summary>💭 Thinking</summary>

Let me also grab the title/alt text since the analysis mentioned it wasn't visible. Actually, the user specifically said to analyze the screenshot not the HTML, so I should respect that. The analysis is complete based on the screenshot. Let me present the findings.

</details>

Today's xkcd is **#3272 — "Time Change"**, a three-panel stick figure comic:

**The comic:**
- **Panel 1:** A stick figure presenting at a podium announces: *"WE ALL HATE SPRINGING FORWARD, BUT WE LOVE FALLING BACK."*
- **Panel 2:** The presenter, now with an audience visible: *"THEREFORE, WE ARE ABOLISHING THE SPRING TIME CHANGE ONLY. WE'LL GAIN AN HOUR EVERY YEAR, BUT NEVER LOSE ONE."*
- **Panel 3:** An audience member raises a hand: *"WON'T THAT CAUSE THE CLOCKS TO SPIRAL OUT OF SYNC WITH THE SUN?"* — to which the presenter replies: *"THEN WE WILL MEET THE CHAOS CLEAR-EYED AND WELL-RESTED!"*

**The joke:** It satirizes the Daylight Saving Time debate by proposing the obviously-unworkable compromise of keeping only the "fall back" (gain-an-hour) change and dropping the "spring forward" (lose-an-hour) one. The result: clocks drift further from solar time every year, but hey — everyone's well-rested.

*(Note: the title/alt text isn't visible in the screenshot since it only appears on hover, and per your request I analyzed the image itself rather than the page HTML.)*

</kbd>
</details> 

## Problems

When using it with GLM-5.2 , it tends to want to use `claude-opus-4.8` since that is at the top of the list .. perhaps some more prompt-massaging is required to encourage it to use more appropriate/affordable models.