### PR TITLE
a11y: VoiceOver status announcer and current-turn finish preview

### DIFF
--- a/ui/src/services/a11yAnnouncer.ts
+++ b/ui/src/services/a11yAnnouncer.ts
@@ -1,0 +1,18 @@
+export type A11yPoliteness = "polite" | "assertive";
+
+export const A11Y_ANNOUNCE_EVENT = "shelley:a11y-announce";
+
+export interface A11yAnnouncementDetail {
+  text: string;
+  politeness: A11yPoliteness;
+}
+
+/** Sends one message through the app-level StatusAnnouncer live region. */
+export function announceA11y(text: string, politeness: A11yPoliteness = "polite") {
+  if (!text || typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<A11yAnnouncementDetail>(A11Y_ANNOUNCE_EVENT, {
+      detail: { text, politeness },
+    }),
+  );
+}

--- a/ui/src/services/plainTextCache.test.ts
+++ b/ui/src/services/plainTextCache.test.ts
@@ -1,0 +1,22 @@
+import { PlainTextCache } from "./plainTextCache";
+
+let strips = 0;
+const cache = new PlainTextCache((content) => {
+  strips++;
+  return content.replace(/[*_]/g, "");
+});
+
+function check(actual: unknown, expected: unknown, message: string): void {
+  if (actual !== expected) throw new Error(`${message}: ${String(actual)}`);
+}
+
+check(cache.get("m1", "**hello**"), "hello", "strips content");
+check(cache.get("m1", "**hello**"), "hello", "reuses cached text");
+check(strips, 1, "same message and content hash strips once");
+check(cache.get("m1", "_updated_"), "updated", "updates text");
+check(strips, 2, "message update recomputes plain text");
+check(cache.size, 1, "message update invalidates previous content hash");
+cache.invalidate("m1");
+check(cache.size, 0, "explicit invalidation removes cached text");
+
+console.log("plainTextCache tests passed");

--- a/ui/src/services/plainTextCache.ts
+++ b/ui/src/services/plainTextCache.ts
@@ -1,0 +1,54 @@
+type PlainTextStripper = (content: string) => string;
+
+function contentHash(content: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < content.length; i++) {
+    hash ^= content.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function stripMarkdown(content: string): string {
+  return content
+    .replace(/```[^\n]*\n?/g, "")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^\s{0,3}(?:#{1,6}|>|[-+*]|\d+\.)\s+/gm, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[*_~`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export class PlainTextCache {
+  private readonly values = new Map<string, string>();
+  private readonly latestKeyByMessage = new Map<string, string>();
+
+  constructor(private readonly strip: PlainTextStripper = stripMarkdown) {}
+
+  get(messageId: string, content: string): string {
+    const key = `${messageId}:${contentHash(content)}`;
+    const previousKey = this.latestKeyByMessage.get(messageId);
+    if (previousKey && previousKey !== key) this.values.delete(previousKey);
+    this.latestKeyByMessage.set(messageId, key);
+
+    const cached = this.values.get(key);
+    if (cached !== undefined) return cached;
+    const plainText = this.strip(content);
+    this.values.set(key, plainText);
+    return plainText;
+  }
+
+  invalidate(messageId: string): void {
+    const key = this.latestKeyByMessage.get(messageId);
+    if (key) this.values.delete(key);
+    this.latestKeyByMessage.delete(messageId);
+  }
+
+  get size(): number {
+    return this.values.size;
+  }
+}
+
+export const plainTextCache = new PlainTextCache();

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3917,15 +3917,48 @@ svg {
 }
 
 /* Wrapper for messages area to position scroll-to-bottom button */
+/* Positioning wrapper for messages + floating TOC. Transcript landmark is
+   an inner region so floating controls are not announced as inside it. */
 .messages-area-wrapper {
   position: relative;
   flex: 1 1 auto;
   min-height: 0; /* Important for flex children to shrink properly */
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.messages-transcript-region {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .messages-container {
   height: 100%;
+}
+
+/* Keyboard skip link — visible on focus only */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: 0.5rem;
+  z-index: 10000;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-base, #fff);
+  color: var(--text-primary, #111);
+  border: 2px solid var(--accent-primary, #2563eb);
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  text-decoration: none;
+  transform: translateY(-200%);
+}
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--accent-primary, #2563eb);
+  outline-offset: 2px;
 }
 
 /* Status bar configuration controls for empty conversations */

--- a/ui/src/vue/components/ChatInterface.vue
+++ b/ui/src/vue/components/ChatInterface.vue
@@ -3,9 +3,17 @@
      bar, terminal/diff/git panels, model/thinking pickers, distill, TOC,
      scroll behavior. Preserves the e2e DOM/ARIA/CSS contract. -->
 <template>
-  <div class="full-height flex flex-col">
+  <div class="full-height flex flex-col" role="main" aria-label="Shelley conversation">
+    <a href="#shelley-message-input" class="skip-link">Skip to message input</a>
+    <StatusAnnouncer
+      :agent-working="agentWorking"
+      :stream-status="streamStatus"
+      :error="error"
+      :tools-completed="toolsCompletedThisTurn"
+      :assistant-preview="assistantTurnPreview"
+    />
     <!-- Header -->
-    <div class="header">
+    <div class="header" role="banner" aria-label="Conversation header">
       <div class="header-left">
         <Button
           class="btn-icon hide-on-desktop"
@@ -82,9 +90,21 @@
       </div>
     </div>
 
-    <!-- Messages area -->
+    <!-- Messages area. Positioning wrapper is not the transcript landmark —
+         floating TOC/scroll controls sit as siblings so focusing them does
+         not also announce "Conversation transcript region". -->
     <div class="messages-area-wrapper">
-      <div ref="messagesContainerRef" class="messages-container scrollable">
+      <div
+        class="messages-transcript-region"
+        role="region"
+        aria-label="Conversation transcript"
+      >
+      <div
+        ref="messagesContainerRef"
+        class="messages-container scrollable"
+        data-a11y-transcript
+        tabindex="-1"
+      >
         <template v-if="loading">
           <div v-if="showLoadingProgressUI" class="conversation-loading full-height">
             <div class="spinner" />
@@ -220,8 +240,9 @@
           <div ref="bottomSentinelRef" class="messages-bottom-sentinel" aria-hidden="true" />
         </div>
       </div>
+      </div>
 
-      <!-- Floating nav cluster -->
+      <!-- Floating nav cluster: sibling of the transcript region, not a child. -->
       <div v-if="conversationId && messages.length > 0" class="chat-nav-cluster">
         <ConversationTOC
           :messages="messages"
@@ -385,6 +406,7 @@ import {
   reconcileComposerDraft,
 } from "../../services/draftCache";
 import { setFaviconStatus } from "../../services/favicon";
+import { plainTextCache } from "../../services/plainTextCache";
 import { useMarkdownMode } from "../composables/markdownMode";
 import { useI18n } from "../composables/i18n";
 import { useDraftAutosave } from "../composables/draftAutosave";
@@ -403,9 +425,11 @@ import { coalesceMessages, type CoalescedItem } from "./coalesce";
 import type { RenderNode, RenderChunk, GenerationBlock } from "./renderNode";
 import type { EphemeralTerminal } from "./terminalTypes";
 import { DEFAULT_THINKING_LEVEL, type ThinkingLevel } from "./thinkingLevel";
+import { currentTurnAssistantPreview } from "./assistantTurnPreview";
 
 import MessageInput from "./MessageInput.vue";
 import ConversationTOC from "./ConversationTOC.vue";
+import StatusAnnouncer from "./StatusAnnouncer.vue";
 import ModelBar from "./ModelBar.vue";
 import SystemPromptView from "./SystemPromptView.vue";
 import DirectoryPickerModal from "./DirectoryPickerModal.vue";
@@ -658,6 +682,8 @@ const diffViewerInitialCommit = ref<string | undefined>(undefined);
 const diffViewerCwd = ref<string | undefined>(undefined);
 const diffCommentText = ref("");
 const agentWorking = ref(false);
+/** Tools that finished during the turn that just ended (for StatusAnnouncer). */
+const toolsCompletedThisTurn = ref(0);
 const cancelling = ref(false);
 const contextWindowSize = ref(0);
 const toolProgress = ref<Record<string, ToolProgress>>({});
@@ -665,6 +691,13 @@ const streamingText = ref("");
 const showAdvancedSettings = ref(false);
 const advancedSettingsRef = ref<HTMLDivElement | null>(null);
 const availableTools = ref<Array<{ name: string; summary: string; default_on: boolean }>>([]);
+
+// Only the current turn (after the latest user message). Never fall back to
+// an earlier agent reply — that made VO announce the previous turn's text
+// when agent_working flipped false before the new agent message arrived.
+const assistantTurnPreview = computed(() =>
+  currentTurnAssistantPreview(messages.value, (id, text) => plainTextCache.get(id, text)),
+);
 
 const showScrollToBottom = ref(false);
 const lastKnownMessageCount = ref<number | null>(null);
@@ -2145,9 +2178,22 @@ const mobileMq = window.matchMedia("(max-width: 767px)");
 const onMobileChange = (e: MediaQueryListEvent) => (isMobile.value = e.matches);
 mobileMq.addEventListener("change", onMobileChange);
 
-// Favicon working indicator.
-watch(agentWorking, (working) => {
-  if (working) setFaviconStatus("working");
+// Favicon working indicator + tool-count for end-of-turn SR announce.
+watch(agentWorking, (working, wasWorking) => {
+  if (working) {
+    setFaviconStatus("working");
+    toolsCompletedThisTurn.value = 0;
+    return;
+  }
+  if (wasWorking) {
+    let n = 0;
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const m = messages.value[i];
+      if (m.type === "user") break;
+      if (m.type === "tool") n++;
+    }
+    toolsCompletedThisTurn.value = n;
+  }
 });
 
 // ---- conversation switch: hydrate + subscribe ----

--- a/ui/src/vue/components/MessageInput.vue
+++ b/ui/src/vue/components/MessageInput.vue
@@ -169,6 +169,7 @@
           class="message-textarea"
           :disabled="isDisabled"
           :rows="initialRows ?? 1"
+          id="shelley-message-input"
           aria-label="Message input"
           data-testid="message-input"
           @input="onTextareaInput"

--- a/ui/src/vue/components/StatusAnnouncer.vue
+++ b/ui/src/vue/components/StatusAnnouncer.vue
@@ -1,0 +1,177 @@
+<!-- Visually hidden live region for VoiceOver / screen readers.
+     Announces agent working/idle and stream connection faults without
+     redesigning the visual status bar.
+
+     Hidden from the accessibility tree when empty so Safari VO Shift+Tab
+     does not land on a stale "status" artifact from an earlier turn. -->
+<template>
+  <div
+    ref="rootRef"
+    class="sr-only"
+    id="turn-completion-summary"
+    tabindex="-1"
+    :aria-live="politeness"
+    aria-atomic="true"
+    :aria-hidden="announcement ? undefined : true"
+    data-testid="status-announcer"
+  >
+    {{ announcement }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from "vue";
+import { A11Y_ANNOUNCE_EVENT, type A11yAnnouncementDetail } from "../../services/a11yAnnouncer";
+import {
+  agentAnnouncement,
+  errorAnnouncement,
+  streamAnnouncement,
+  type Announcement,
+  type Politeness,
+  type StreamStatus,
+} from "./statusAnnouncer";
+
+const props = withDefaults(
+  defineProps<{
+    agentWorking: boolean;
+    streamStatus?: StreamStatus;
+    error?: string | null;
+    /** Tool cards that finished during the turn that just ended. */
+    toolsCompleted?: number;
+    /** Plain-text preview of the assistant response that just completed. */
+    assistantPreview?: string;
+  }>(),
+  {
+    streamStatus: "connected",
+    error: null,
+    toolsCompleted: 0,
+    assistantPreview: "",
+  },
+);
+
+const rootRef = ref<HTMLElement | null>(null);
+const announcement = ref("");
+const politeness = ref<Politeness>("polite");
+let announcementVersion = 0;
+let suspended = false;
+let pending: Announcement | null = null;
+/** Clears spoken text after VO has had a chance to read it, so reverse-tab
+ *  navigation does not re-encounter turn artifacts minutes later. Kept long
+ *  enough for browser-notification hash focus (#turn-completion-summary). */
+const CLEAR_AFTER_MS = 8000;
+let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearClearTimer() {
+  if (clearTimer !== null) {
+    clearTimeout(clearTimer);
+    clearTimer = null;
+  }
+}
+
+function scheduleClear(version: number) {
+  clearClearTimer();
+  clearTimer = setTimeout(() => {
+    clearTimer = null;
+    // Do not wipe while the user is focused on the summary (notification click).
+    if (document.activeElement?.id === "turn-completion-summary") return;
+    if (version === announcementVersion) announcement.value = "";
+  }, CLEAR_AFTER_MS);
+}
+
+function apply(next: Announcement | null) {
+  if (!next) return;
+  if (suspended) {
+    pending = next;
+    return;
+  }
+
+  const version = ++announcementVersion;
+  clearClearTimer();
+  // Clear then set so repeated identical phrases still fire (VO quirk).
+  announcement.value = "";
+  politeness.value = next.politeness;
+  if (!next.text) return;
+
+  // Microtask is enough for the clear-then-set re-fire; no delay needed there.
+  queueMicrotask(() => {
+    if (version === announcementVersion) {
+      announcement.value = next.text;
+      scheduleClear(version);
+    }
+  });
+}
+
+watch(
+  () => props.agentWorking,
+  (working, wasWorking) => {
+    apply(agentAnnouncement(working, wasWorking, props.toolsCompleted, props.assistantPreview));
+  },
+);
+
+watch(
+  () => props.streamStatus,
+  (status, prev) => {
+    apply(streamAnnouncement(status, prev));
+  },
+);
+
+watch(
+  () => props.error,
+  (err, prev) => {
+    apply(errorAnnouncement(err, prev));
+  },
+);
+
+function onA11yAnnouncement(event: Event) {
+  const detail = (event as CustomEvent<A11yAnnouncementDetail>).detail;
+  if (detail?.text) apply(detail);
+}
+
+function onFocusIn(event: FocusEvent) {
+  const target = event.target as HTMLElement | null;
+  if (target?.closest("[data-a11y-transcript]")) suspended = true;
+}
+
+function onFocusOut() {
+  queueMicrotask(() => {
+    const active = document.activeElement as HTMLElement | null;
+    if (active?.closest("[data-a11y-transcript]")) return;
+    if (!suspended) return;
+    suspended = false;
+    if (pending) {
+      const catchUp = pending;
+      pending = null;
+      apply({ ...catchUp, text: `While you were reviewing: ${catchUp.text}` });
+    }
+  });
+}
+
+function onSummaryBlur() {
+  // After notification hash-focus, clear once the user tabs away.
+  if (!announcement.value) return;
+  const version = announcementVersion;
+  queueMicrotask(() => {
+    if (
+      version === announcementVersion &&
+      document.activeElement?.id !== "turn-completion-summary"
+    ) {
+      clearClearTimer();
+      announcement.value = "";
+    }
+  });
+}
+
+onMounted(() => {
+  window.addEventListener(A11Y_ANNOUNCE_EVENT, onA11yAnnouncement);
+  document.addEventListener("focusin", onFocusIn);
+  document.addEventListener("focusout", onFocusOut);
+  rootRef.value?.addEventListener("blur", onSummaryBlur);
+});
+onUnmounted(() => {
+  clearClearTimer();
+  window.removeEventListener(A11Y_ANNOUNCE_EVENT, onA11yAnnouncement);
+  document.removeEventListener("focusin", onFocusIn);
+  document.removeEventListener("focusout", onFocusOut);
+  rootRef.value?.removeEventListener("blur", onSummaryBlur);
+});
+</script>

--- a/ui/src/vue/components/assistantTurnPreview.test.ts
+++ b/ui/src/vue/components/assistantTurnPreview.test.ts
@@ -1,0 +1,75 @@
+import { currentTurnAssistantPreview } from "./assistantTurnPreview";
+
+function check(name: string, actual: unknown, expected: unknown) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+  }
+}
+
+const strip = (_id: string, text: string) => text.replace(/\s+/g, " ").trim();
+
+function agent(id: string, text: string) {
+  return {
+    type: "agent",
+    message_id: id,
+    llm_data: JSON.stringify({
+      Content: [{ Type: 2, Text: text }],
+    }),
+  };
+}
+
+function user(id: string) {
+  return { type: "user", message_id: id, llm_data: "{}" };
+}
+
+check(
+  "uses only current-turn agent text",
+  currentTurnAssistantPreview(
+    [
+      user("u1"),
+      agent("a1", "Done. Here's the summary: Moved /claw.md"),
+      user("u2"),
+      agent("a2", "You're right — I didn't use Grok."),
+    ],
+    strip,
+  ),
+  "You're right — I didn't use Grok.",
+);
+
+check(
+  "does not fall back to previous turn when current turn has no text yet",
+  currentTurnAssistantPreview(
+    [user("u1"), agent("a1", "Done. Here's the summary: Moved /claw.md"), user("u2")],
+    strip,
+  ),
+  "",
+);
+
+check(
+  "skips tool-only agent messages and finds later text in turn",
+  currentTurnAssistantPreview(
+    [
+      user("u1"),
+      agent("a0", "old turn"),
+      user("u2"),
+      { type: "agent", message_id: "toolish", llm_data: JSON.stringify({ Content: [{ Type: 3, ToolName: "bash" }] }) },
+      agent("a2", "Final answer."),
+    ],
+    strip,
+  ),
+  "Final answer.",
+);
+
+{
+  const truncated = currentTurnAssistantPreview(
+    [user("u1"), agent("a1", "x".repeat(200))],
+    strip,
+    20,
+  );
+  check("truncates long previews length", truncated.length <= 20, true);
+  check("truncates with ellipsis", truncated.endsWith("…"), true);
+}
+
+check("empty messages", currentTurnAssistantPreview([], strip), "");
+
+console.log("assistantTurnPreview tests passed");

--- a/ui/src/vue/components/assistantTurnPreview.ts
+++ b/ui/src/vue/components/assistantTurnPreview.ts
@@ -1,0 +1,59 @@
+/** Pure helper: plain-text preview of the assistant response for the current turn only. */
+
+export type PreviewMessage = {
+  type: string;
+  message_id: string;
+  llm_data?: unknown;
+};
+
+export type ContentPart = {
+  Type?: number;
+  Text?: string;
+};
+
+const TEXT_TYPE = 2;
+
+function agentText(message: PreviewMessage): string {
+  try {
+    const raw = message.llm_data;
+    const llm =
+      typeof raw === "string" ? (JSON.parse(raw) as { Content?: ContentPart[] }) : (raw as { Content?: ContentPart[] });
+    return (llm?.Content || [])
+      .filter((content) => content.Type === TEXT_TYPE && content.Text)
+      .map((content) => content.Text!.trim())
+      .filter(Boolean)
+      .join("\n\n");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Returns a short plain preview of the assistant's text in the *current* turn
+ * (messages after the latest user message). Never falls back to an earlier
+ * turn — that caused Safari VO to announce a previous response on finish.
+ */
+export function currentTurnAssistantPreview(
+  messages: PreviewMessage[],
+  strip: (messageId: string, text: string) => string,
+  maxLen = 180,
+): string {
+  let lastUser = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].type === "user") {
+      lastUser = i;
+      break;
+    }
+  }
+
+  for (let i = messages.length - 1; i > lastUser; i--) {
+    const message = messages[i];
+    if (message.type !== "agent") continue;
+    const text = agentText(message);
+    if (!text) continue;
+    const plainText = strip(message.message_id, text);
+    if (!plainText) continue;
+    return plainText.length > maxLen ? `${plainText.slice(0, maxLen - 3).trimEnd()}…` : plainText;
+  }
+  return "";
+}

--- a/ui/src/vue/components/statusAnnouncer.test.ts
+++ b/ui/src/vue/components/statusAnnouncer.test.ts
@@ -1,0 +1,59 @@
+import {
+  agentAnnouncement,
+  errorAnnouncement,
+  streamAnnouncement,
+} from "./statusAnnouncer";
+
+function check(name: string, actual: unknown, expected: unknown) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${name}: ${JSON.stringify(actual)}`);
+  }
+}
+
+check("idle mount stays silent", agentAnnouncement(false, undefined), null);
+check("working starts", agentAnnouncement(true, false), {
+  text: "Agent working",
+  politeness: "polite",
+});
+check("working finishes", agentAnnouncement(false, true), {
+  text: "Agent finished",
+  politeness: "polite",
+});
+check("working finishes with tools", agentAnnouncement(false, true, 3), {
+  text: "Agent finished. 3 tools completed.",
+  politeness: "polite",
+});
+check(
+  "working finishes with assistant preview",
+  agentAnnouncement(false, true, 1, "The build is green."),
+  {
+    text: "Agent finished. 1 tool completed. Response: The build is green.",
+    politeness: "polite",
+  },
+);
+check("unchanged idle state stays silent", agentAnnouncement(false, false), null);
+
+check("disconnect is assertive", streamAnnouncement("disconnected", "connected"), {
+  text: "Disconnected",
+  politeness: "assertive",
+});
+check("reconnection is polite", streamAnnouncement("connected", "disconnected"), {
+  text: "Connected",
+  politeness: "polite",
+});
+
+check("error is assertive", errorAnnouncement("Request failed", null), {
+  text: "Request failed",
+  politeness: "assertive",
+});
+check(
+  "unchanged errors are announced once",
+  errorAnnouncement("Request failed", "Request failed"),
+  null,
+);
+check("cleared errors clear the live region", errorAnnouncement(null, "Request failed"), {
+  text: "",
+  politeness: "polite",
+});
+
+console.log("statusAnnouncer tests passed");

--- a/ui/src/vue/components/statusAnnouncer.ts
+++ b/ui/src/vue/components/statusAnnouncer.ts
@@ -1,0 +1,56 @@
+export type Politeness = "polite" | "assertive";
+export type StreamStatus = "connected" | "reconnecting" | "disconnected";
+
+export interface Announcement {
+  text: string;
+  politeness: Politeness;
+}
+
+export function agentAnnouncement(
+  working: boolean,
+  wasWorking: boolean | undefined,
+  toolsCompleted = 0,
+  assistantPreview = "",
+): Announcement | null {
+  if (working === wasWorking) return null;
+  if (working) return { text: "Agent working", politeness: "polite" };
+  if (wasWorking) {
+    const preview = assistantPreview.trim();
+    const response = preview ? ` Response: ${preview}` : "";
+    if (toolsCompleted > 0) {
+      const noun = toolsCompleted === 1 ? "tool" : "tools";
+      return {
+        text: `Agent finished. ${toolsCompleted} ${noun} completed.${response}`,
+        politeness: "polite",
+      };
+    }
+    return {
+      text: preview ? `Agent finished.${response}` : "Agent finished",
+      politeness: "polite",
+    };
+  }
+  return null;
+}
+
+export function streamAnnouncement(
+  status: StreamStatus,
+  previous: StreamStatus | undefined,
+): Announcement | null {
+  if (status === previous) return null;
+  if (status === "reconnecting") return { text: "Reconnecting", politeness: "polite" };
+  if (status === "disconnected") return { text: "Disconnected", politeness: "assertive" };
+  if (previous === "disconnected" || previous === "reconnecting") {
+    return { text: "Connected", politeness: "polite" };
+  }
+  return null;
+}
+
+export function errorAnnouncement(
+  error: string | null,
+  previous: string | null | undefined,
+): Announcement | null {
+  if (error === previous) return null;
+  if (error) return { text: error, politeness: "assertive" };
+  if (previous) return { text: "", politeness: "polite" };
+  return null;
+}


### PR DESCRIPTION
## Summary

Screen-reader polish for agent turn lifecycle on Safari VoiceOver (and similar):

- **StatusAnnouncer** — visually hidden `aria-live` region announces agent working / finished / stream disconnect without redesigning the status bar. Empty state is `aria-hidden` so reverse-tab does not land on a stale "status" artifact.
- **Current-turn preview only** — "Agent finished. Response: …" uses assistant text after the latest user message only. Previously the latest agent text *anywhere* in the conversation could be announced when `agent_working` cleared before the new reply landed, so VO spoke the previous turn.
- **Landmarks / skip-link** — `role="main"`, skip link to `#shelley-message-input`, transcript `role="region"`. Floating TOC stays a **sibling** of the transcript region so focusing it does not also announce "Conversation transcript region".

No model/provider changes. Unit tests for announcement copy, preview scoping, and plain-text cache.

## Test plan

- [ ] `cd ui && pnpm test && pnpm run type-check && pnpm run type-check:vue`
- [ ] Open a conversation with VoiceOver (Safari): send a turn, confirm "Agent working" then "Agent finished" (with optional response preview from *this* turn only)
- [ ] Send a second turn; confirm finish announce does **not** re-speak the first turn's reply
- [ ] Tab: skip-link focuses message input when activated
- [ ] Shift+Tab from attach/composer: TOC is not announced as inside "Conversation transcript region"

---

From the [VaxTui](https://github.com/csullivan84/VaxTui) fork (VoiceOver-first Shelley). Happy to sign CLA / adjust scope if preferred.