### PR TITLE
Keep background models on the conversation gateway

### DIFF
--- a/claudetool/bash.go
+++ b/claudetool/bash.go
@@ -184,11 +184,10 @@ func (b *BashTool) run(ctx context.Context, req bashInput) llm.ToolOut {
 		}
 	}
 
-	// Check for missing tools and try to install them if needed, best effort only
+	// Check for missing tools and install them before executing the command.
 	if b.EnableJITInstall {
-		err := b.checkAndInstallMissingTools(ctx, req.Command)
-		if err != nil {
-			slog.DebugContext(ctx, "failed to auto-install missing tools", "error", err)
+		if err := b.checkAndInstallMissingTools(ctx, req.Command); err != nil {
+			return llm.ErrorfToolOut("automatic tool installation failed: %w", err)
 		}
 	}
 
@@ -505,11 +504,11 @@ func (b *BashTool) checkAndInstallMissingTools(ctx context.Context, command stri
 	}
 
 	for _, cmd := range missing {
-		err := b.installTool(ctx, cmd)
-		if err != nil {
+		if err := b.installTool(ctx, cmd); err != nil {
 			slog.WarnContext(ctx, "failed to install tool", "tool", cmd, "error", err)
+			return fmt.Errorf("install %s: %w", cmd, err)
 		}
-		doNotAttemptToolInstall[cmd] = true // either it's installed or it's not--either way, we're done with it
+		doNotAttemptToolInstall[cmd] = true
 	}
 	return nil
 }

--- a/claudetool/bash.go
+++ b/claudetool/bash.go
@@ -182,11 +182,10 @@ func (b *BashTool) run(ctx context.Context, req bashInput) llm.ToolOut {
 		}
 	}
 
-	// Check for missing tools and try to install them if needed, best effort only
+	// Check for missing tools and install them before executing the command.
 	if b.EnableJITInstall {
-		err := b.checkAndInstallMissingTools(ctx, req.Command)
-		if err != nil {
-			slog.DebugContext(ctx, "failed to auto-install missing tools", "error", err)
+		if err := b.checkAndInstallMissingTools(ctx, req.Command); err != nil {
+			return llm.ErrorfToolOut("automatic tool installation failed: %w", err)
 		}
 	}
 
@@ -525,11 +524,11 @@ func (b *BashTool) checkAndInstallMissingTools(ctx context.Context, command stri
 	}
 
 	for _, cmd := range missing {
-		err := b.installTool(ctx, cmd)
-		if err != nil {
+		if err := b.installTool(ctx, cmd); err != nil {
 			slog.WarnContext(ctx, "failed to install tool", "tool", cmd, "error", err)
+			return fmt.Errorf("install %s: %w", cmd, err)
 		}
-		doNotAttemptToolInstall[cmd] = true // either it's installed or it's not--either way, we're done with it
+		doNotAttemptToolInstall[cmd] = true
 	}
 	return nil
 }

--- a/claudetool/bash_test.go
+++ b/claudetool/bash_test.go
@@ -143,6 +143,25 @@ func TestBashTool(t *testing.T) {
 	})
 }
 
+func TestBashJITInstallFailureIsToolError(t *testing.T) {
+	const command = "shelley-definitely-missing-command"
+	autoInstallMu.Lock()
+	delete(doNotAttemptToolInstall, command)
+	autoInstallMu.Unlock()
+
+	tool := (&BashTool{
+		WorkingDir:       NewMutableWorkingDir("/"),
+		EnableJITInstall: true,
+	}).Tool()
+	out := tool.Run(context.Background(), json.RawMessage(`{"command":"`+command+`"}`))
+	if out.Error == nil {
+		t.Fatal("expected missing command installation to return a tool error")
+	}
+	if got := out.Error.Error(); !strings.Contains(got, "automatic tool installation failed") || !strings.Contains(got, command) {
+		t.Fatalf("error = %q, want explicit installation failure for %s", got, command)
+	}
+}
+
 func TestExecuteBash(t *testing.T) {
 	ctx := context.Background()
 	bashTool := &BashTool{WorkingDir: NewMutableWorkingDir("/")}

--- a/claudetool/bash_test.go
+++ b/claudetool/bash_test.go
@@ -145,6 +145,25 @@ func TestBashTool(t *testing.T) {
 	})
 }
 
+func TestBashJITInstallFailureIsToolError(t *testing.T) {
+	const command = "shelley-definitely-missing-command"
+	autoInstallMu.Lock()
+	delete(doNotAttemptToolInstall, command)
+	autoInstallMu.Unlock()
+
+	tool := (&BashTool{
+		WorkingDir:       NewMutableWorkingDir("/"),
+		EnableJITInstall: true,
+	}).Tool()
+	out := tool.Run(context.Background(), json.RawMessage(`{"command":"`+command+`"}`))
+	if out.Error == nil {
+		t.Fatal("expected missing command installation to return a tool error")
+	}
+	if got := out.Error.Error(); !strings.Contains(got, "automatic tool installation failed") || !strings.Contains(got, command) {
+		t.Fatalf("error = %q, want explicit installation failure for %s", got, command)
+	}
+}
+
 func TestChainedCdHint(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/claudetool/shell.go
+++ b/claudetool/shell.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -204,7 +203,7 @@ func (s *ShellTool) run(ctx context.Context, req shellInput) llm.ToolOut {
 		// independent of the BashTool struct beyond the LLM provider.
 		bt := &BashTool{LLMProvider: s.LLMProvider, ModelID: s.ModelID}
 		if err := bt.checkAndInstallMissingTools(ctx, req.Command); err != nil {
-			slog.DebugContext(ctx, "failed to auto-install missing tools", "error", err)
+			return llm.ErrorfToolOut("automatic tool installation failed: %w", err)
 		}
 	}
 

--- a/claudetool/shell_test.go
+++ b/claudetool/shell_test.go
@@ -62,6 +62,23 @@ func TestShellQuickCommand(t *testing.T) {
 	}
 }
 
+func TestShellJITInstallFailureIsToolError(t *testing.T) {
+	const command = "shelley-definitely-missing-shell-command"
+	autoInstallMu.Lock()
+	delete(doNotAttemptToolInstall, command)
+	autoInstallMu.Unlock()
+
+	s := newTestShell(t)
+	s.EnableJITInstall = true
+	_, _, err := runShell(t, s, `{"command":"`+command+`"}`, 10*time.Second)
+	if err == nil {
+		t.Fatal("expected missing command installation to return a tool error")
+	}
+	if got := err.Error(); !strings.Contains(got, "automatic tool installation failed") || !strings.Contains(got, command) {
+		t.Fatalf("error = %q, want explicit installation failure for %s", got, command)
+	}
+}
+
 func TestShellYieldsOnLongCommand(t *testing.T) {
 	s := newTestShell(t)
 	s.DefaultYield = 500 * time.Millisecond

--- a/models/workhorse.go
+++ b/models/workhorse.go
@@ -32,9 +32,9 @@ var workhorseFamilies = map[Provider]workhorseFamily{
 	ProviderFireworks: {contains: "deepseek-v4-flash"},
 }
 
-// WorkhorseDo sends req to a cheap model from the conversation's provider. If
-// that call fails, or no workhorse is configured, it uses the conversation
-// model once.
+// WorkhorseDo sends req to a cheap model from the conversation's exact
+// upstream gateway/account. If that call fails, or no workhorse is configured
+// on that gateway, it uses the conversation model once.
 func WorkhorseDo(ctx context.Context, p WorkhorseProvider, conversationModelID string, req *llm.Request) (*llm.Response, error) {
 	modelID := workhorseModel(p, conversationModelID)
 	if modelID == "" {
@@ -73,7 +73,11 @@ func workhorseModel(c WorkhorseProvider, conversationModelID string) string {
 	bestDate := ""
 	for _, modelID := range c.GetAvailableModels() {
 		candidate := c.GetModelInfo(modelID)
-		if candidate == nil || candidate.Provider != info.Provider || !matchesWorkhorseFamily(modelID, family) {
+		if candidate == nil ||
+			candidate.Provider != info.Provider ||
+			candidate.BaseURL != info.BaseURL ||
+			candidate.Source != info.Source ||
+			!matchesWorkhorseFamily(modelID, family) {
 			continue
 		}
 		if bestID == "" || candidate.ReleaseDate > bestDate {

--- a/models/workhorse.go
+++ b/models/workhorse.go
@@ -103,7 +103,11 @@ func (m *Manager) workhorseModel(conversationModelID string) string {
 	bestDate := ""
 	for _, modelID := range m.GetAvailableModels() {
 		candidate := m.GetModelInfo(modelID)
-		if candidate == nil || candidate.Provider != info.Provider || !matchesWorkhorseFamily(modelID, family) {
+		if candidate == nil ||
+			candidate.Provider != info.Provider ||
+			candidate.BaseURL != info.BaseURL ||
+			candidate.Source != info.Source ||
+			!matchesWorkhorseFamily(modelID, family) {
 			continue
 		}
 		if bestID == "" || candidate.ReleaseDate > bestDate {

--- a/models/workhorse_test.go
+++ b/models/workhorse_test.go
@@ -12,6 +12,8 @@ type fakeCatalog struct {
 	ids       []string
 	providers map[string]Provider
 	dates     map[string]string
+	sources   map[string]string
+	baseURLs  map[string]string
 	services  map[string]*recordingService
 }
 
@@ -22,7 +24,13 @@ func (f *fakeCatalog) GetModelInfo(modelID string) *ModelInfo {
 	if !ok {
 		return nil
 	}
-	return &ModelInfo{DisplayName: modelID, Provider: provider, ReleaseDate: f.dates[modelID]}
+	return &ModelInfo{
+		DisplayName: modelID,
+		Provider:    provider,
+		ReleaseDate: f.dates[modelID],
+		Source:      f.sources[modelID],
+		BaseURL:     f.baseURLs[modelID],
+	}
 }
 
 func (f *fakeCatalog) GetService(modelID string) (llm.Service, error) {
@@ -100,6 +108,44 @@ func TestWorkhorseModel(t *testing.T) {
 		if got := workhorseModel(catalog, test.conversationModel); got != test.want {
 			t.Errorf("workhorseModel(%q) = %q, want %q", test.conversationModel, got, test.want)
 		}
+	}
+}
+
+func TestWorkhorseModelStaysOnConversationGateway(t *testing.T) {
+	catalog := &fakeCatalog{
+		ids: []string{
+			"gpt-5.6-terra@priyanka",
+			"gpt-5.7-luna@chelsea",
+			"gpt-5.6-luna@priyanka",
+		},
+		providers: map[string]Provider{
+			"gpt-5.6-terra@priyanka": ProviderOpenAI,
+			"gpt-5.7-luna@chelsea":   ProviderOpenAI,
+			"gpt-5.6-luna@priyanka":  ProviderOpenAI,
+		},
+		dates: map[string]string{
+			"gpt-5.7-luna@chelsea":  "2026-08-15",
+			"gpt-5.6-luna@priyanka": "2026-07-09",
+		},
+		sources: map[string]string{
+			"gpt-5.6-terra@priyanka": "priyanka gateway",
+			"gpt-5.7-luna@chelsea":   "chelsea gateway",
+			"gpt-5.6-luna@priyanka":  "priyanka gateway",
+		},
+		baseURLs: map[string]string{
+			"gpt-5.6-terra@priyanka": "https://priyanka.example",
+			"gpt-5.7-luna@chelsea":   "https://chelsea.example",
+			"gpt-5.6-luna@priyanka":  "https://priyanka.example",
+		},
+	}
+
+	if got := workhorseModel(catalog, "gpt-5.6-terra@priyanka"); got != "gpt-5.6-luna@priyanka" {
+		t.Fatalf("workhorseModel() = %q, want Priyanka's Luna", got)
+	}
+
+	delete(catalog.providers, "gpt-5.6-luna@priyanka")
+	if got := workhorseModel(catalog, "gpt-5.6-terra@priyanka"); got != "gpt-5.6-terra@priyanka" {
+		t.Fatalf("workhorseModel() = %q, want conversation model rather than cross-gateway fallback", got)
 	}
 }
 

--- a/models/workhorse_test.go
+++ b/models/workhorse_test.go
@@ -82,6 +82,33 @@ func TestWorkhorseModel(t *testing.T) {
 	}
 }
 
+func TestWorkhorseModelStaysOnConversationGateway(t *testing.T) {
+	conversation := Built{
+		ID: "gpt-5.6-terra@priyanka", Provider: ProviderOpenAI,
+		Source: "priyanka gateway", BaseURL: "https://priyanka.example",
+	}
+	otherGateway := Built{
+		ID: "gpt-5.7-luna@chelsea", Provider: ProviderOpenAI, ReleaseDate: "2026-08-15",
+		Source: "chelsea gateway", BaseURL: "https://chelsea.example",
+	}
+	sameGateway := Built{
+		ID: "gpt-5.6-luna@priyanka", Provider: ProviderOpenAI, ReleaseDate: "2026-07-09",
+		Source: "priyanka gateway", BaseURL: "https://priyanka.example",
+	}
+
+	manager := newWorkhorseManager(t, conversation, otherGateway, sameGateway)
+	if got := manager.workhorseModel(conversation.ID); got != sameGateway.ID {
+		t.Fatalf("workhorseModel(%q) = %q, want same-gateway %q", conversation.ID, got, sameGateway.ID)
+	}
+
+	// Without a same-gateway workhorse, stay on the conversation model rather
+	// than crossing to another gateway's newer model.
+	manager = newWorkhorseManager(t, conversation, otherGateway)
+	if got := manager.workhorseModel(conversation.ID); got != conversation.ID {
+		t.Fatalf("workhorseModel(%q) = %q, want conversation model rather than cross-gateway fallback", conversation.ID, got)
+	}
+}
+
 func TestGetWorkhorseServiceUsesSelectedPrimary(t *testing.T) {
 	workhorse := &optionalRecordingService{recordingService: &recordingService{
 		provider:           "anthropic",


### PR DESCRIPTION
Match workhorse models by provider, source, and base URL so background requests cannot cross user accounts. Return JIT installation failures as explicit Bash and Shell tool errors instead of swallowing them.