### PR TITLE
Restore favicon when agent stops work

### DIFF
--- a/ui/src/vue/components/ChatInterface.vue
+++ b/ui/src/vue/components/ChatInterface.vue
@@ -3338,9 +3338,16 @@ const onMobileChange = (e: MediaQueryListEvent) => (isMobile.value = e.matches);
 mobileMq.addEventListener("change", onMobileChange);
 
 // Favicon working indicator.
-watch(agentWorking, (working) => {
-  if (working) setFaviconStatus("working");
-});
+watch(
+  agentWorking,
+  (working) => {
+    // The completion notification is best-effort: a sleeping/backgrounded tab
+    // can miss it. The conversation's authoritative working state is also
+    // restored by the stream/list-patch path, so derive both transitions here.
+    setFaviconStatus(working ? "working" : "ready");
+  },
+  { immediate: true },
+);
 
 // ---- conversation switch: hydrate + subscribe ----
 let unsubStore: (() => void) | null = null;


### PR DESCRIPTION
Shelley tells me that this will make favicon undimming more reliable. I haven't reproduced the bug I saw once, but it's a small change and makes sense.

> Likely cause:

> The favicon was dimmed when agentWorking became true.
> It was restored only by the separate agent_done/agent_error notification.
> A sleeping laptop can freeze the tab or kill its SSE connection, so that notification may be missed.
> Worse, the agentWorking watcher only handled the true transition; it never restored the favicon when state later became false.