### PR TITLE
skills: support ~/.agents/ for AGENTS.md and skills

### DIFF
--- a/server/system_prompt.go
+++ b/server/system_prompt.go
@@ -736,11 +736,13 @@ func collectCodebaseInfo(wd string, gitInfo *GitInfo) (*CodebaseInfo, error) {
 	seenFiles := make(map[string]bool)
 	seenContents := make(map[string]bool)
 
-	// Check for user-level agent instructions in ~/.config/AGENTS.md, ~/.config/shelley/AGENTS.md, and ~/.shelley/AGENTS.md
+	// Check for user-level agent instructions in ~/.config/AGENTS.md,
+	// ~/.config/shelley/AGENTS.md, ~/.agents/AGENTS.md, and ~/.shelley/AGENTS.md
 	if home, err := os.UserHomeDir(); err == nil {
 		userAgentsFiles := []string{
 			filepath.Join(home, ".config", "AGENTS.md"),
 			filepath.Join(home, ".config", "shelley", "AGENTS.md"),
+			filepath.Join(home, ".agents", "AGENTS.md"),
 			filepath.Join(home, ".shelley", "AGENTS.md"),
 		}
 		for _, f := range userAgentsFiles {

--- a/server/system_prompt_test.go
+++ b/server/system_prompt_test.go
@@ -201,20 +201,27 @@ func TestSystemPromptIncludesUserEmail(t *testing.T) {
 // user-level AGENTS.md files have identical content (or are symlinks to the same
 // file), only one copy appears in the system prompt.
 func TestSystemPromptDeduplicatesIdenticalGuidanceFiles(t *testing.T) {
-	// Create a fake home with two AGENTS.md locations containing the same content
+	// Create a fake home with three AGENTS.md locations containing the same content
 	tmpHome := t.TempDir()
 
 	configShelley := filepath.Join(tmpHome, ".config", "shelley")
+	dotAgents := filepath.Join(tmpHome, ".agents")
 	dotShelley := filepath.Join(tmpHome, ".shelley")
 	if err := os.MkdirAll(configShelley, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dotAgents, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(dotShelley, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	agentsContent := "DEDUP_TEST_MARKER: identical content in both files"
+	agentsContent := "DEDUP_TEST_MARKER: identical content in all locations"
 	if err := os.WriteFile(filepath.Join(configShelley, "AGENTS.md"), []byte(agentsContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dotAgents, "AGENTS.md"), []byte(agentsContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dotShelley, "AGENTS.md"), []byte(agentsContent), 0o644); err != nil {
@@ -275,6 +282,33 @@ func TestSystemPromptDeduplicatesSymlinkedGuidanceFiles(t *testing.T) {
 	count := strings.Count(prompt, "SYMLINK_DEDUP_MARKER")
 	if count != 1 {
 		t.Errorf("expected SYMLINK_DEDUP_MARKER to appear exactly 1 time, got %d", count)
+	}
+}
+
+// TestSystemPromptIncludesDotAgentsAgentsMd verifies that a user-level
+// AGENTS.md in ~/.agents/ is injected into the system prompt.
+func TestSystemPromptIncludesDotAgentsAgentsMd(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	dotAgents := filepath.Join(tmpHome, ".agents")
+	if err := os.MkdirAll(dotAgents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentsContent := "DOT_AGENTS_MARKER: instructions from ~/.agents"
+	if err := os.WriteFile(filepath.Join(dotAgents, "AGENTS.md"), []byte(agentsContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpHome)
+
+	unrelatedDir := t.TempDir()
+	prompt, err := GenerateSystemPrompt(unrelatedDir)
+	if err != nil {
+		t.Fatalf("GenerateSystemPrompt failed: %v", err)
+	}
+
+	if !strings.Contains(prompt, agentsContent) {
+		t.Errorf("system prompt should contain content from ~/.agents/AGENTS.md")
 	}
 }
 

--- a/skills/skills.go
+++ b/skills/skills.go
@@ -364,10 +364,12 @@ func DefaultDirs() []string {
 	// Search these directories for skills:
 	// 1. ~/.config/shelley/ (XDG convention for Shelley)
 	// 2. ~/.config/agents/skills (shared agents skills directory)
-	// 3. ~/.shelley/ (legacy location)
+	// 3. ~/.agents/skills (non-XDG alternative to ~/.config/agents/skills)
+	// 4. ~/.shelley/ (legacy location)
 	candidateDirs := []string{
 		filepath.Join(home, ".config", "shelley"),
 		filepath.Join(home, ".config", "agents", "skills"),
+		filepath.Join(home, ".agents", "skills"),
 		filepath.Join(home, ".shelley"),
 	}
 

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -473,12 +473,13 @@ func TestDefaultDirsReturnsExistingCandidates(t *testing.T) {
 	// Create a fake home directory with skill directories
 	tmpHome := t.TempDir()
 
-	// Create all three candidate directories
+	// Create all four candidate directories
 	configShelley := filepath.Join(tmpHome, ".config", "shelley")
 	configAgents := filepath.Join(tmpHome, ".config", "agents", "skills")
+	dotAgentsSkills := filepath.Join(tmpHome, ".agents", "skills")
 	dotShelley := filepath.Join(tmpHome, ".shelley")
 
-	for _, dir := range []string{configShelley, configAgents, dotShelley} {
+	for _, dir := range []string{configShelley, configAgents, dotAgentsSkills, dotShelley} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -491,19 +492,20 @@ func TestDefaultDirsReturnsExistingCandidates(t *testing.T) {
 
 	dirs := DefaultDirs()
 
-	if len(dirs) != 3 {
-		t.Fatalf("expected 3 dirs, got %d: %v", len(dirs), dirs)
+	if len(dirs) != 4 {
+		t.Fatalf("expected 4 dirs, got %d: %v", len(dirs), dirs)
 	}
 
-	// Verify all three candidates are returned
-	want := map[string]bool{
-		configShelley: true,
-		configAgents:  true,
-		dotShelley:    true,
+	// Verify all four candidates are returned, in order
+	want := []string{
+		configShelley,
+		configAgents,
+		dotAgentsSkills,
+		dotShelley,
 	}
-	for _, d := range dirs {
-		if !want[d] {
-			t.Errorf("unexpected dir in result: %s", d)
+	for i, d := range dirs {
+		if d != want[i] {
+			t.Errorf("dirs[%d] = %s, want %s", i, d, want[i])
 		}
 	}
 }
@@ -548,6 +550,14 @@ func TestSkillsFoundRegardlessOfWorkingDir(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: my-skill\ndescription: A test skill.\n---\nContent\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// And a skill in ~/.agents/skills/ (non-XDG alternative location)
+	dotAgentsSkillDir := filepath.Join(tmpHome, ".agents", "skills", "my-dot-agents-skill")
+	if err := os.MkdirAll(dotAgentsSkillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dotAgentsSkillDir, "SKILL.md"), []byte("---\nname: my-dot-agents-skill\ndescription: A test skill in ~/.agents.\n---\nContent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	oldHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpHome)
@@ -561,11 +571,15 @@ func TestSkillsFoundRegardlessOfWorkingDir(t *testing.T) {
 	dirs := DefaultDirs()
 	found := Discover(dirs)
 
-	if len(found) != 1 {
-		t.Fatalf("expected 1 skill, got %d (dirs=%v)", len(found), dirs)
+	if len(found) != 2 {
+		t.Fatalf("expected 2 skills, got %d (dirs=%v)", len(found), dirs)
 	}
-	if found[0].Name != "my-skill" {
-		t.Errorf("expected my-skill, got %s", found[0].Name)
+	gotNames := map[string]bool{}
+	for _, s := range found {
+		gotNames[s.Name] = true
+	}
+	if !gotNames["my-skill"] || !gotNames["my-dot-agents-skill"] {
+		t.Errorf("expected my-skill and my-dot-agents-skill, got %v", gotNames)
 	}
 
 	// DiscoverInTree from the project dir should NOT find user-level skills
@@ -575,10 +589,10 @@ func TestSkillsFoundRegardlessOfWorkingDir(t *testing.T) {
 		t.Errorf("expected 0 tree skills from unrelated project, got %d", len(treeSkills))
 	}
 
-	// But the combined result should still have the skill
+	// But the combined result should still have both skills
 	all := append(found, treeSkills...)
-	if len(all) != 1 {
-		t.Fatalf("expected 1 total skill, got %d", len(all))
+	if len(all) != 2 {
+		t.Fatalf("expected 2 total skills, got %d", len(all))
 	}
 
 	_ = projectDir // used above


### PR DESCRIPTION
~/.agents/ is a non-XDG alternative to the ~/.config/agents layout used by several other tools already, so mirror both of its halves in the discovery paths:

- ~/.agents/AGENTS.md: user-level agent instructions, checked right after ~/.config/shelley/AGENTS.md
- ~/.agents/skills/<name>/SKILL.md: user skills, checked right after ~/.config/agents/skills