### PR TITLE
shelley: support SHELLEY_CUSTOM_HEADERS on all LLM requests

### DIFF
--- a/cmd/shelley/main.go
+++ b/cmd/shelley/main.go
@@ -459,7 +459,8 @@ func buildLLMConfig(global GlobalConfig, logger *slog.Logger, database *db.DB) (
 
 	defaultModel, sources := buildLLMModelSources(context.Background(), global, config, logger)
 
-	httpc := llmhttp.NewClient(nil)
+	customHeaders := llmhttp.ParseCustomHeaders(os.Getenv("SHELLEY_CUSTOM_HEADERS"))
+	httpc := llmhttp.NewClientWithOptions(nil, llmhttp.DefaultIdleTimeout, customHeaders)
 	return &server.LLMConfig{
 		Models:       modelsources.Build(models.All(), sources, httpc, logger),
 		DefaultModel: defaultModel,

--- a/llm/llmhttp/llmhttp.go
+++ b/llm/llmhttp/llmhttp.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -143,6 +144,10 @@ type Transport struct {
 	// it measures the gap between chunks (and time-to-first-byte), not total
 	// duration. Zero disables the mechanism.
 	IdleTimeout time.Duration
+	// CustomHeaders are user-configured headers applied to every LLM request.
+	// They are applied after Shelley's own headers, so a custom header may
+	// override one Shelley sets.
+	CustomHeaders http.Header
 }
 
 // RoundTrip implements http.RoundTripper.
@@ -179,6 +184,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Add x-session-affinity header for Fireworks to enable prompt caching
 		if ProviderFromContext(req.Context()) == "fireworks" {
 			req.Header.Set("x-session-affinity", conversationID)
+		}
+	}
+
+	// Apply user-configured custom headers last, so they may override any
+	// header Shelley set above.
+	for name, values := range t.CustomHeaders {
+		req.Header.Del(name)
+		for _, value := range values {
+			req.Header.Add(name, value)
 		}
 	}
 
@@ -327,12 +341,18 @@ func (r *idleReadCloser) Close() error {
 // NewClient creates an http.Client with Shelley headers applied via Transport
 // and the default idle/stall timeout.
 func NewClient(base *http.Client) *http.Client {
-	return NewClientWithIdleTimeout(base, DefaultIdleTimeout)
+	return NewClientWithOptions(base, DefaultIdleTimeout, nil)
 }
 
 // NewClientWithIdleTimeout is like NewClient but with an explicit idle/stall
 // timeout. A value <= 0 disables the idle timeout.
 func NewClientWithIdleTimeout(base *http.Client, idleTimeout time.Duration) *http.Client {
+	return NewClientWithOptions(base, idleTimeout, nil)
+}
+
+// NewClientWithOptions is like NewClientWithIdleTimeout but also applies the
+// given custom headers to every request. A nil or empty header set is a no-op.
+func NewClientWithOptions(base *http.Client, idleTimeout time.Duration, customHeaders http.Header) *http.Client {
 	if base == nil {
 		base = http.DefaultClient
 	}
@@ -343,7 +363,32 @@ func NewClientWithIdleTimeout(base *http.Client, idleTimeout time.Duration) *htt
 	}
 
 	return &http.Client{
-		Transport: &Transport{Base: transport, IdleTimeout: idleTimeout},
+		Transport: &Transport{Base: transport, IdleTimeout: idleTimeout, CustomHeaders: customHeaders},
 		Timeout:   base.Timeout,
 	}
+}
+
+// ParseCustomHeaders parses a newline-separated list of "Name: Value" HTTP
+// header lines into an http.Header. Blank lines and lines without a colon are
+// skipped, and surrounding whitespace on the name and value is trimmed. Repeated
+// names accumulate multiple values. It returns nil when no valid headers are
+// found.
+func ParseCustomHeaders(s string) http.Header {
+	var headers http.Header
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name, value, ok := strings.Cut(line, ":")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			continue
+		}
+		if headers == nil {
+			headers = http.Header{}
+		}
+		headers.Add(name, strings.TrimSpace(value))
+	}
+	return headers
 }

--- a/llm/llmhttp/llmhttp_test.go
+++ b/llm/llmhttp/llmhttp_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -128,6 +129,75 @@ func TestTransportAddsSessionAffinityForFireworks(t *testing.T) {
 	// Verify Shelley-Conversation-Id header was also added
 	if got := receivedHeaders.Get("Shelley-Conversation-Id"); got != "test-conv-id" {
 		t.Errorf("Shelley-Conversation-Id = %q, want %q", got, "test-conv-id")
+	}
+}
+
+func TestParseCustomHeaders(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string][]string
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "whitespace only", in: "  \n\t\n", want: nil},
+		{name: "no colon", in: "not a header", want: nil},
+		{name: "single", in: "X-Tenant-Id: tenant-abc123", want: map[string][]string{"X-Tenant-Id": {"tenant-abc123"}}},
+		{
+			name: "multiple lines with blanks and whitespace",
+			in:   "  X-A :  one \n\n X-B:two\n",
+			want: map[string][]string{"X-A": {"one"}, "X-B": {"two"}},
+		},
+		{name: "value with colon", in: "X-Url: https://example.com:8080/p", want: map[string][]string{"X-Url": {"https://example.com:8080/p"}}},
+		{name: "empty value", in: "X-Empty:", want: map[string][]string{"X-Empty": {""}}},
+		{name: "empty name skipped", in: ": value", want: nil},
+		{name: "repeated name accumulates", in: "X-A: one\nX-A: two", want: map[string][]string{"X-A": {"one", "two"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseCustomHeaders(tc.in)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("ParseCustomHeaders(%q) = %v, want nil", tc.in, got)
+				}
+				return
+			}
+			for name, values := range tc.want {
+				if gotValues := got.Values(name); !slices.Equal(gotValues, values) {
+					t.Errorf("header %q = %v, want %v", name, gotValues, values)
+				}
+			}
+			if len(got) != len(tc.want) {
+				t.Errorf("got %d headers, want %d (%v)", len(got), len(tc.want), got)
+			}
+		})
+	}
+}
+
+func TestTransportAppliesCustomHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	headers := ParseCustomHeaders("X-Tenant-Id: tenant-abc123\nUser-Agent: override")
+	client := NewClientWithOptions(nil, DefaultIdleTimeout, headers)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := receivedHeaders.Get("X-Tenant-Id"); got != "tenant-abc123" {
+		t.Errorf("X-Tenant-Id = %q, want %q", got, "tenant-abc123")
+	}
+	// Custom headers are applied last, so they override Shelley's own headers.
+	if got := receivedHeaders.Get("User-Agent"); got != "override" {
+		t.Errorf("User-Agent = %q, want %q (custom header should override)", got, "override")
 	}
 }
 


### PR DESCRIPTION
## What

Adds a general custom-HTTP-headers knob so operators can attach arbitrary headers to **every** outbound LLM request, via the single `llmhttp.Transport` chokepoint. Configured with a new env var:

```bash
SHELLEY_CUSTOM_HEADERS="X-Tenant-Id: tenant-abc123"
```

- Format is `Name: Value`, **newline-separated** for multiple headers (repeated names accumulate).
- Applies to every provider — Anthropic, OpenAI, Gemini, Fireworks, the exe.dev gateway, and DB-backed custom models — since they all share the client built by `llmhttp.NewClient`.
- Custom headers are applied **after** Shelley's own headers (`User-Agent`, `Shelley-Request-Id`, `Shelley-Conversation-Id`), so a custom header may override one Shelley sets.

## Why

Mirrors Claude Code's `ANTHROPIC_CUSTOM_HEADERS`, whose documented purpose is an escape hatch for a gateway/proxy that requires a **tenant or routing header** on every request (headers a gateway may consume for routing, attribution, or tracing). `X-Tenant-Id` is the de facto convention for that.

## Design notes

- Env var is **not** a provider credential, so it does not reopen the frozen per-provider API-key env vars called out in `buildLLMModelSources` (`ANTHROPIC_API_KEY`, etc.).
- Parsing lives in `main.go` (reads the env var), consistent with Shelley's env-config convention; the reusable `ParseCustomHeaders`/`NewClientWithOptions` live in `llmhttp` and are unit-tested.

## Changes

- `llm/llmhttp/llmhttp.go` — `Transport.CustomHeaders` field, applied in `RoundTrip`; `NewClientWithOptions(...)` constructor; `ParseCustomHeaders(string) http.Header`.
- `cmd/shelley/main.go` — parse `SHELLEY_CUSTOM_HEADERS` and pass into the client.
- `llm/llmhttp/llmhttp_test.go` — parser table test + transport integration test.

## Testing

`go test ./llm/llmhttp/` passes; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)