### PR TITLE
Expose the request purpose as a Shelley-Request-Purpose header

### DIFF
--- a/llm/llmhttp/llmhttp.go
+++ b/llm/llmhttp/llmhttp.go
@@ -32,6 +32,11 @@ const (
 // logs, so a user-reported id can be correlated with the server-side trace_id.
 const shelleyRequestIDHeader = "Shelley-Request-Id"
 
+// shelleyRequestPurposeHeader carries the purpose tag of an indirect LLM call
+// (slug, keyword_search, tool_install, compaction, ...) so gateways in front of
+// Shelley can distinguish background chores from conversation turns.
+const shelleyRequestPurposeHeader = "Shelley-Request-Purpose"
+
 // upstreamRequestIDHeaders are response headers, in priority order, that
 // providers use to expose their own request/correlation id. The exe.dev
 // gateway strips account-identifying headers (Cf-Ray, rate limits, org) but
@@ -180,6 +185,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if ProviderFromContext(req.Context()) == "fireworks" {
 			req.Header.Set("x-session-affinity", conversationID)
 		}
+	}
+
+	// Add the request purpose header if the call is tagged with one
+	if purpose := llm.PurposeFromContext(req.Context()); purpose != "" {
+		req.Header.Set(shelleyRequestPurposeHeader, purpose)
 	}
 
 	base := t.Base

--- a/llm/llmhttp/llmhttp_test.go
+++ b/llm/llmhttp/llmhttp_test.go
@@ -94,6 +94,39 @@ func TestTransportAddsHeaders(t *testing.T) {
 	if got := receivedHeaders.Get("x-session-affinity"); got != "" {
 		t.Errorf("x-session-affinity = %q, want empty for non-fireworks", got)
 	}
+
+	// Verify Shelley-Request-Purpose is NOT added without a purpose in context
+	if got := receivedHeaders.Get("Shelley-Request-Purpose"); got != "" {
+		t.Errorf("Shelley-Request-Purpose = %q, want empty without a purpose", got)
+	}
+}
+
+func TestTransportAddsPurposeHeader(t *testing.T) {
+	// Create a test server that echoes request headers
+	var receivedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	client := NewClient(nil)
+
+	// Make a request with a purpose in context
+	ctx := llm.WithPurpose(context.Background(), "slug")
+	req, _ := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	// Verify Shelley-Request-Purpose header was added
+	if got := receivedHeaders.Get("Shelley-Request-Purpose"); got != "slug" {
+		t.Errorf("Shelley-Request-Purpose = %q, want %q", got, "slug")
+	}
 }
 
 func TestTransportAddsSessionAffinityForFireworks(t *testing.T) {


### PR DESCRIPTION
Shelley already tags indirect LLM calls with a purpose (via `llm.WithPurpose`) for usage accounting — slug generation, keyword search, tool-install validation, compaction, subagent progress. That tag never reaches the wire today, so gateways and proxies in front of Shelley can't tell background chores apart from conversation turns; the only wire signal is the model id, which is ambiguous when the workhorse falls back to the conversation model.

This PR emits the purpose as a `Shelley-Request-Purpose` header on outgoing LLM requests, alongside the existing `Shelley-Request-Id` and `Shelley-Conversation-Id` headers, so gateways can observe, route, and bill background traffic separately.

Additive-only: when no purpose is set on the context, no header is sent and nothing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mAtm2pot4r1wk6G9GBiWg