### PR TITLE
ui: polish generation context metadata

### DIFF
--- a/claudetool/registry.go
+++ b/claudetool/registry.go
@@ -4,9 +4,10 @@ import "shelley.exe.dev/llm"
 
 // ToolInfo describes a tool available to conversations.
 type ToolInfo struct {
-	Name      string `json:"name"`
-	Summary   string `json:"summary"`
-	DefaultOn bool   `json:"default_on"`
+	Name       string `json:"name"`
+	Summary    string `json:"summary"`
+	DefaultOn  bool   `json:"default_on"`
+	SourcePath string `json:"-"`
 }
 
 // ToolRegistry lists every tool that a Shelley conversation can use, along with
@@ -15,16 +16,29 @@ type ToolInfo struct {
 //
 // Keep in sync with NewToolSet / browse.RegisterBrowserTools.
 var ToolRegistry = []ToolInfo{
-	{Name: "bash", Summary: "Run shell commands.", DefaultOn: true},
-	{Name: "shell", Summary: "Run shell commands.", DefaultOn: false},
-	{Name: "patch", Summary: "Precise edits to files.", DefaultOn: true},
-	{Name: "keyword_search", Summary: "Search the codebase by keyword.", DefaultOn: true},
-	{Name: "change_dir", Summary: "Change the working directory.", DefaultOn: true},
-	{Name: "output_iframe", Summary: "Show HTML/visualizations to the user.", DefaultOn: true},
-	{Name: "subagent", Summary: "Spawn a subagent conversation.", DefaultOn: true},
-	{Name: "llm_one_shot", Summary: "One-shot prompt to another LLM.", DefaultOn: true},
-	{Name: "browser", Summary: "Browser automation (navigate, eval, screenshot, emulate, network, accessibility, profile).", DefaultOn: true},
-	{Name: "read_image", Summary: "Read an image file for the model.", DefaultOn: true},
+	{Name: "bash", Summary: "Run shell commands.", DefaultOn: true, SourcePath: "claudetool/bash.go"},
+	{Name: "shell", Summary: "Run shell commands.", DefaultOn: false, SourcePath: "claudetool/shell.go"},
+	{Name: "patch", Summary: "Precise edits to files.", DefaultOn: true, SourcePath: "claudetool/patch.go"},
+	{Name: "keyword_search", Summary: "Search the codebase by keyword.", DefaultOn: true, SourcePath: "claudetool/keyword.go"},
+	{Name: "change_dir", Summary: "Change the working directory.", DefaultOn: true, SourcePath: "claudetool/changedir.go"},
+	{Name: "output_iframe", Summary: "Show HTML/visualizations to the user.", DefaultOn: true, SourcePath: "claudetool/output_iframe.go"},
+	{Name: "subagent", Summary: "Spawn a subagent conversation.", DefaultOn: true, SourcePath: "claudetool/subagent.go"},
+	{Name: "llm_one_shot", Summary: "One-shot prompt to another LLM.", DefaultOn: true, SourcePath: "claudetool/llm_one_shot.go"},
+	{Name: "browser", Summary: "Browser automation (navigate, eval, screenshot, emulate, network, accessibility, profile).", DefaultOn: true, SourcePath: "claudetool/browse/browse.go"},
+	{Name: "read_image", Summary: "Read an image file for the model.", DefaultOn: true, SourcePath: "claudetool/browse/browse.go"},
+}
+
+// ToolInfoByName returns registry metadata for a tool.
+func ToolInfoByName(name string) (ToolInfo, bool) {
+	if name == "apply_patch" {
+		name = "patch"
+	}
+	for _, tool := range ToolRegistry {
+		if tool.Name == name {
+			return tool, true
+		}
+	}
+	return ToolInfo{}, false
 }
 
 // IsToolEnabled reports whether a tool with the given name is enabled for a

--- a/claudetool/registry_test.go
+++ b/claudetool/registry_test.go
@@ -2,11 +2,32 @@ package claudetool
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
 	"shelley.exe.dev/llm"
 )
+
+func TestToolRegistrySourcesExist(t *testing.T) {
+	for _, tool := range ToolRegistry {
+		if tool.SourcePath == "" {
+			t.Fatalf("tool %q has no source path", tool.Name)
+		}
+		if _, err := os.Stat(filepath.Join("..", tool.SourcePath)); err != nil {
+			t.Fatalf("tool %q source %q: %v", tool.Name, tool.SourcePath, err)
+		}
+		found, ok := ToolInfoByName(tool.Name)
+		if !ok || found.SourcePath != tool.SourcePath {
+			t.Fatalf("ToolInfoByName(%q) = %+v, %v", tool.Name, found, ok)
+		}
+	}
+	patch, ok := ToolInfoByName("apply_patch")
+	if !ok || patch.SourcePath != "claudetool/patch.go" {
+		t.Fatalf("apply_patch source = %+v, %v", patch, ok)
+	}
+}
 
 func TestIsToolEnabled(t *testing.T) {
 	cases := []struct {

--- a/server/convo.go
+++ b/server/convo.go
@@ -19,6 +19,7 @@ import (
 	"shelley.exe.dev/llm"
 	"shelley.exe.dev/llm/llmhttp"
 	"shelley.exe.dev/loop"
+	"shelley.exe.dev/skills"
 	"shelley.exe.dev/subpub"
 )
 
@@ -1789,7 +1790,7 @@ func (cm *ConversationManager) createSystemPrompt(ctx context.Context) (*generat
 	if cm.userEmail != "" {
 		opts = append(opts, WithUserEmail(cm.userEmail))
 	}
-	systemPrompt, err := GenerateSystemPrompt(cm.cwd, opts...)
+	systemPrompt, promptSkills, err := generateSystemPrompt(cm.cwd, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate system prompt: %w", err)
 	}
@@ -1809,7 +1810,7 @@ func (cm *ConversationManager) createSystemPrompt(ctx context.Context) (*generat
 		Type:           db.MessageTypeSystem,
 		LLMData:        systemMessage,
 		UsageData:      llm.Usage{},
-		DisplayData:    cm.systemPromptDisplayData(),
+		DisplayData:    cm.systemPromptDisplayData(promptSkills),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to store system prompt: %w", err)
@@ -1824,46 +1825,96 @@ func (cm *ConversationManager) createSystemPrompt(ctx context.Context) (*generat
 	return created, nil
 }
 
-// toolDisplayData builds display data from a list of tools.
-func toolDisplayData(tools []*llm.Tool) map[string]any {
+// systemPromptDisplayData builds the tool and skill metadata shown alongside a
+// persisted system prompt. Skill bodies stay out of display data; the card only
+// needs discovery metadata and the activation command.
+func systemPromptDisplayData(cfg claudetool.ToolSetConfig, promptSkills []skills.Skill) map[string]any {
 	type toolDesc struct {
 		Name        string          `json:"name"`
 		Description string          `json:"description"`
 		Parameters  json.RawMessage `json:"parameters,omitempty"`
+		SourcePath  string          `json:"source_path,omitempty"`
+		Origin      string          `json:"origin"`
+		Type        string          `json:"type,omitempty"`
+		ServerSide  bool            `json:"server_side,omitempty"`
 	}
-	var descs []toolDesc
-	for _, t := range tools {
-		var params json.RawMessage
-		if len(t.InputSchema) > 0 && string(t.InputSchema) != "null" {
-			params = t.InputSchema
-		}
-		descs = append(descs, toolDesc{
-			Name:        t.Name,
-			Description: t.Description,
-			Parameters:  params,
-		})
+	type skillDesc struct {
+		Name          string            `json:"name"`
+		Description   string            `json:"description"`
+		Activate      string            `json:"activate"`
+		SourcePath    string            `json:"source_path"`
+		Origin        string            `json:"origin"`
+		License       string            `json:"license,omitempty"`
+		Compatibility string            `json:"compatibility,omitempty"`
+		When          string            `json:"when,omitempty"`
+		AllowedTools  string            `json:"allowed_tools,omitempty"`
+		Metadata      map[string]string `json:"metadata,omitempty"`
 	}
-	return map[string]any{
-		"tools": descs,
-	}
-}
 
-// systemPromptDisplayData returns display data for normal system prompt messages.
-func systemPromptDisplayData(cfg claudetool.ToolSetConfig) map[string]any {
 	ts := claudetool.NewToolSet(context.Background(), cfg)
 	defer ts.Cleanup()
-	return toolDisplayData(ts.Tools())
+
+	toolDescs := make([]toolDesc, 0, len(ts.Tools()))
+	for _, tool := range ts.Tools() {
+		var params json.RawMessage
+		if len(tool.InputSchema) > 0 && string(tool.InputSchema) != "null" {
+			params = tool.InputSchema
+		}
+		origin := "Shelley"
+		sourcePath := ""
+		if tool.ServerSide {
+			origin = "Provider"
+		} else if info, ok := claudetool.ToolInfoByName(tool.Name); ok {
+			sourcePath = info.SourcePath
+		}
+		toolDescs = append(toolDescs, toolDesc{
+			Name:        tool.Name,
+			Description: tool.Description,
+			Parameters:  params,
+			SourcePath:  sourcePath,
+			Origin:      origin,
+			Type:        tool.Type,
+			ServerSide:  tool.ServerSide,
+		})
+	}
+
+	skillDescs := make([]skillDesc, 0, len(promptSkills))
+	for _, skill := range promptSkills {
+		sourcePath := skill.Path
+		origin := "File"
+		if sourcePath == "" {
+			sourcePath = "skills/builtin/" + skill.Name + "/SKILL.md"
+			origin = "Built into Shelley"
+		}
+		skillDescs = append(skillDescs, skillDesc{
+			Name:          skill.Name,
+			Description:   skill.Description,
+			Activate:      "shelley skill cat " + skill.Name,
+			SourcePath:    sourcePath,
+			Origin:        origin,
+			License:       skill.License,
+			Compatibility: skill.Compatibility,
+			When:          skill.When,
+			AllowedTools:  skill.AllowedTools,
+			Metadata:      skill.Metadata,
+		})
+	}
+
+	return map[string]any{
+		"tools":  toolDescs,
+		"skills": skillDescs,
+	}
 }
 
-func (cm *ConversationManager) systemPromptDisplayData() map[string]any {
+func (cm *ConversationManager) systemPromptDisplayData(promptSkills []skills.Skill) map[string]any {
 	cfg := cm.toolSetConfig
 	cfg.ToolOverrides = cm.conversationOptions.ToolOverrides
 	cfg.DisableAllTools = cm.conversationOptions.DisableAllTools
-	return systemPromptDisplayData(cfg)
+	return systemPromptDisplayData(cfg, promptSkills)
 }
 
 func (cm *ConversationManager) createSubagentSystemPrompt(ctx context.Context, parentConversationID string) (*generated.Message, error) {
-	systemPrompt, err := GenerateSubagentSystemPrompt(cm.cwd, parentConversationID)
+	systemPrompt, promptSkills, err := generateSubagentSystemPrompt(cm.cwd, parentConversationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate subagent system prompt: %w", err)
 	}
@@ -1883,7 +1934,7 @@ func (cm *ConversationManager) createSubagentSystemPrompt(ctx context.Context, p
 		Type:           db.MessageTypeSystem,
 		LLMData:        systemMessage,
 		UsageData:      llm.Usage{},
-		DisplayData:    cm.systemPromptDisplayData(),
+		DisplayData:    cm.systemPromptDisplayData(promptSkills),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to store subagent system prompt: %w", err)

--- a/server/convo_test.go
+++ b/server/convo_test.go
@@ -8,9 +8,65 @@ import (
 	"strings"
 	"testing"
 
+	"shelley.exe.dev/claudetool"
 	"shelley.exe.dev/db"
 	"shelley.exe.dev/db/generated"
+	"shelley.exe.dev/skills"
 )
+
+func TestSystemPromptDisplayDataIncludesSourceMetadata(t *testing.T) {
+	t.Parallel()
+	displayData := systemPromptDisplayData(
+		claudetool.ToolSetConfig{
+			DisableAllTools: true,
+			ToolOverrides:   map[string]string{"bash": "on"},
+		},
+		[]skills.Skill{
+			{Name: "file-skill", Description: "From disk.", Path: "/tmp/file-skill/SKILL.md"},
+			{Name: "schedule", Description: "Built in."},
+		},
+	)
+
+	encoded, err := json.Marshal(displayData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Tools []struct {
+			Name       string `json:"name"`
+			SourcePath string `json:"source_path"`
+			Origin     string `json:"origin"`
+		} `json:"tools"`
+		Skills []struct {
+			Name       string `json:"name"`
+			Activate   string `json:"activate"`
+			SourcePath string `json:"source_path"`
+			Origin     string `json:"origin"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Tools) != 1 || got.Tools[0].Name != "bash" {
+		t.Fatalf("tools = %+v, want bash only", got.Tools)
+	}
+	if got.Tools[0].SourcePath != "claudetool/bash.go" || got.Tools[0].Origin != "Shelley" {
+		t.Errorf("bash metadata = %+v", got.Tools[0])
+	}
+	if len(got.Skills) != 2 {
+		t.Fatalf("skills = %+v", got.Skills)
+	}
+	if got.Skills[0].SourcePath != "/tmp/file-skill/SKILL.md" || got.Skills[0].Origin != "File" {
+		t.Errorf("file skill metadata = %+v", got.Skills[0])
+	}
+	if got.Skills[1].SourcePath != "skills/builtin/schedule/SKILL.md" || got.Skills[1].Origin != "Built into Shelley" {
+		t.Errorf("built-in skill metadata = %+v", got.Skills[1])
+	}
+	if got.Skills[1].Activate != "shelley skill cat schedule" {
+		t.Errorf("schedule activation = %q", got.Skills[1].Activate)
+	}
+}
 
 func TestHydrateGeneratesSystemPromptWithSubagentTool(t *testing.T) {
 	t.Parallel()

--- a/server/system_prompt.go
+++ b/server/system_prompt.go
@@ -38,6 +38,7 @@ type SystemPromptData struct {
 	Hostname         string // For exe.dev, the public hostname (e.g., "vmname.exe.xyz")
 	DefaultPort      int    // For exe.dev, the auto-routed HTTP port, 0 if unknown
 	SkillsXML        string // XML block for available skills
+	Skills           []skills.Skill
 	UserEmail        string // The exe.dev auth email of the user, if known
 }
 
@@ -89,9 +90,14 @@ func WithUserEmail(email string) SystemPromptOption {
 // GenerateSystemPrompt generates the system prompt using the embedded template.
 // If workingDir is empty, it uses the current working directory.
 func GenerateSystemPrompt(workingDir string, opts ...SystemPromptOption) (string, error) {
+	prompt, _, err := generateSystemPrompt(workingDir, opts...)
+	return prompt, err
+}
+
+func generateSystemPrompt(workingDir string, opts ...SystemPromptOption) (string, []skills.Skill, error) {
 	data, err := collectSystemData(workingDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to collect system data: %w", err)
+		return "", nil, fmt.Errorf("failed to collect system data: %w", err)
 	}
 
 	for _, opt := range opts {
@@ -100,17 +106,21 @@ func GenerateSystemPrompt(workingDir string, opts ...SystemPromptOption) (string
 
 	tmpl, err := template.New("system_prompt").Parse(systemPromptTemplate)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse template: %w", err)
+		return "", nil, fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	var buf strings.Builder
 	err = tmpl.Execute(&buf, data)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute template: %w", err)
+		return "", nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 
 	prompt := collapseBlankLines(buf.String())
-	return runHook(hookSystemPrompt, prompt)
+	prompt, err = runHook(hookSystemPrompt, prompt)
+	if err != nil {
+		return "", nil, err
+	}
+	return prompt, data.Skills, nil
 }
 
 // collapseBlankLines reduces runs of 3+ newlines to 2 (one blank line)
@@ -673,7 +683,7 @@ func collectSystemData(workingDir string) (*SystemPromptData, error) {
 	var (
 		codebaseInfo *CodebaseInfo
 		codebaseErr  error
-		skillsXML    string
+		foundSkills  []skills.Skill
 		wg           sync.WaitGroup
 	)
 	wg.Add(2)
@@ -683,7 +693,7 @@ func collectSystemData(workingDir string) (*SystemPromptData, error) {
 	}()
 	go func() {
 		defer wg.Done()
-		skillsXML = collectSkills(wd, gitRoot, skills.Env{ExeDev: data.IsExeDev})
+		foundSkills = collectSkills(wd, gitRoot, skills.Env{ExeDev: data.IsExeDev})
 	}()
 
 	// Run the remaining cheap synchronous probes while the walks are in flight.
@@ -703,7 +713,8 @@ func collectSystemData(workingDir string) (*SystemPromptData, error) {
 	if codebaseErr == nil {
 		data.Codebase = codebaseInfo
 	}
-	data.SkillsXML = skillsXML
+	data.Skills = foundSkills
+	data.SkillsXML = skills.ToPromptXML(foundSkills)
 
 	return data, nil
 }
@@ -929,8 +940,8 @@ func exeDevDefaultPortIn(env exeenv.Environment) int {
 // collectSkills discovers skills from default directories, project .skills dirs,
 // the project tree, and built-in skills. See skills.ListAll for precedence rules.
 // Skills with a `when:` clause are filtered against env.
-func collectSkills(workingDir, gitRoot string, env skills.Env) string {
-	return skills.ToPromptXML(skills.Filter(skills.ListAll(workingDir, gitRoot), env))
+func collectSkills(workingDir, gitRoot string, env skills.Env) []skills.Skill {
+	return skills.Filter(skills.ListAll(workingDir, gitRoot), env)
 }
 
 // resolveAndNormalize returns a canonical lowercase path for dedup.
@@ -955,16 +966,22 @@ type SubagentSystemPromptData struct {
 	ShelleyDBPath    string
 	ConversationID   string // Parent conversation ID for querying user messages
 	SkillsXML        string // XML block for available skills
+	Skills           []skills.Skill
 }
 
 // GenerateSubagentSystemPrompt generates a minimal system prompt for subagent conversations.
 func GenerateSubagentSystemPrompt(workingDir, parentConversationID string) (string, error) {
+	prompt, _, err := generateSubagentSystemPrompt(workingDir, parentConversationID)
+	return prompt, err
+}
+
+func generateSubagentSystemPrompt(workingDir, parentConversationID string) (string, []skills.Skill, error) {
 	wd := workingDir
 	if wd == "" {
 		var err error
 		wd, err = os.Getwd()
 		if err != nil {
-			return "", fmt.Errorf("failed to get working directory: %w", err)
+			return "", nil, fmt.Errorf("failed to get working directory: %w", err)
 		}
 	}
 
@@ -985,19 +1002,24 @@ func GenerateSubagentSystemPrompt(workingDir, parentConversationID string) (stri
 	if gitInfo != nil {
 		gitRoot = gitInfo.Root
 	}
-	data.SkillsXML = collectSkills(wd, gitRoot, skills.Env{ExeDev: isExeDev()})
+	data.Skills = collectSkills(wd, gitRoot, skills.Env{ExeDev: isExeDev()})
+	data.SkillsXML = skills.ToPromptXML(data.Skills)
 
 	tmpl, err := template.New("subagent_system_prompt").Parse(subagentSystemPromptTemplate)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse subagent template: %w", err)
+		return "", nil, fmt.Errorf("failed to parse subagent template: %w", err)
 	}
 
 	var buf strings.Builder
 	err = tmpl.Execute(&buf, data)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute subagent template: %w", err)
+		return "", nil, fmt.Errorf("failed to execute subagent template: %w", err)
 	}
 
 	prompt := collapseBlankLines(buf.String())
-	return runHook(hookSystemPrompt, prompt)
+	prompt, err = runHook(hookSystemPrompt, prompt)
+	if err != nil {
+		return "", nil, err
+	}
+	return prompt, data.Skills, nil
 }

--- a/server/system_prompt_test.go
+++ b/server/system_prompt_test.go
@@ -161,9 +161,9 @@ func TestSystemPromptIncludesSkillsFromAnyWorkingDir(t *testing.T) {
 
 	// Generate system prompt from a directory completely unrelated to home
 	unrelatedDir := t.TempDir()
-	prompt, err := GenerateSystemPrompt(unrelatedDir)
+	prompt, promptSkills, err := generateSystemPrompt(unrelatedDir)
 	if err != nil {
-		t.Fatalf("GenerateSystemPrompt failed: %v", err)
+		t.Fatalf("generateSystemPrompt failed: %v", err)
 	}
 
 	if !strings.Contains(prompt, "test-skill") {
@@ -171,6 +171,18 @@ func TestSystemPromptIncludesSkillsFromAnyWorkingDir(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "A test skill for issue 83.") {
 		t.Error("system prompt should contain the skill description")
+	}
+
+	var foundPath string
+	for _, skill := range promptSkills {
+		if skill.Name == "test-skill" {
+			foundPath = skill.Path
+			break
+		}
+	}
+	wantPath := filepath.Join(skillDir, "SKILL.md")
+	if foundPath != wantPath {
+		t.Errorf("test-skill path = %q, want %q", foundPath, wantPath)
 	}
 }
 

--- a/ui/e2e/generation-context.spec.ts
+++ b/ui/e2e/generation-context.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+import { createConversationViaAPIWithDetails } from "./helpers";
+
+test("groups model and system prompt into one context card", async ({ page, request }) => {
+  await page.setViewportSize({ width: 1000, height: 800 });
+  const conversation = await createConversationViaAPIWithDetails(request, "echo: context card");
+
+  await page.goto(`/c/${conversation.slug}`);
+  await expect(page.getByTestId("message-input")).toBeVisible({ timeout: 30000 });
+
+  const card = page.getByTestId("generation-context");
+  await expect(card).toBeVisible();
+  await expect(card.locator(":scope > .model-bar")).toBeVisible();
+  await expect(card.locator(":scope > .system-prompt-view")).toBeVisible();
+  const modelSummary = card.locator(".model-bar-summary");
+  const promptButton = card.getByRole("button", {
+    name: /System Prompt:\s*\d+ tools?\s*,?\s*\d+ skills? Expand/,
+  });
+  await expect(promptButton).toBeVisible();
+  await expect(modelSummary).toContainText("Model:");
+  await expect(modelSummary).not.toContainText("Reasoning");
+  await expect(promptButton).toContainText(/System Prompt:\s*\d+ tools?,\s*\d+ skills?/);
+  expect(
+    await promptButton.evaluate((element) => ({
+      boxShadow: getComputedStyle(element).boxShadow,
+      borderLeftWidth: getComputedStyle(element).borderLeftWidth,
+    })),
+  ).toEqual({ boxShadow: "none", borderLeftWidth: "0px" });
+
+  await modelSummary
+    .locator(".model-bar-name")
+    .first()
+    .evaluate((element) => {
+      element.textContent = "a-very-long-custom-model-name-".repeat(12);
+    });
+  const [cardRect, promptRect] = await Promise.all([
+    card.evaluate((element) => element.getBoundingClientRect().toJSON()),
+    promptButton.evaluate((element) => element.getBoundingClientRect().toJSON()),
+  ]);
+  expect(promptRect.width).toBeGreaterThan(200);
+  expect(promptRect.right).toBeLessThanOrEqual(cardRect.right + 1);
+
+  const lineRects = await Promise.all([
+    modelSummary.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { top: rect.top, bottom: rect.bottom };
+    }),
+    promptButton.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { top: rect.top, bottom: rect.bottom };
+    }),
+  ]);
+  expect(Math.abs(lineRects[0].top - lineRects[1].top)).toBeLessThan(1);
+  expect(Math.abs(lineRects[0].bottom - lineRects[1].bottom)).toBeLessThan(1);
+
+  await page.setViewportSize({ width: 540, height: 800 });
+  await expect(promptButton).toBeVisible();
+
+  const skillCount = Number((await promptButton.textContent())?.match(/(\d+) skills?/)?.[1]);
+  const toolCount = Number((await promptButton.textContent())?.match(/(\d+) tools?/)?.[1]);
+  expect(skillCount).toBeGreaterThan(0);
+  expect(toolCount).toBeGreaterThan(0);
+  await promptButton.click();
+  await expect(
+    card.getByRole("button", {
+      name: /System Prompt:\s*\d+ tools?\s*,?\s*\d+ skills? Collapse/,
+    }),
+  ).toBeVisible();
+  await expect(card.locator(".system-prompt-content")).toBeVisible();
+  await expect(card.locator(".system-prompt-skill-item")).toHaveCount(skillCount);
+  await expect(card.locator(".system-prompt-tool-item")).toHaveCount(toolCount);
+
+  const skillCard = card.locator(".system-prompt-skill-item").first();
+  await skillCard.locator(".system-prompt-card-summary").click();
+  await expect(skillCard.locator(".system-prompt-card-detail")).toBeVisible();
+  await expect(skillCard.locator(".system-prompt-card-detail")).toContainText("Source");
+  await expect(skillCard.locator(".system-prompt-card-detail code").first()).toContainText(
+    "SKILL.md",
+  );
+
+  const toolCard = card.locator(".system-prompt-tool-item").first();
+  await toolCard.locator(".system-prompt-card-summary").click();
+  await expect(toolCard.locator(".system-prompt-card-detail")).toBeVisible();
+  await expect(toolCard.locator(".system-prompt-card-detail")).toContainText("Source");
+  await expect(toolCard.locator(".system-prompt-card-detail code").first()).toContainText(
+    "claudetool/",
+  );
+
+  const childSurfaces = await card
+    .locator(":scope > .model-bar, :scope > .system-prompt-view")
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const style = getComputedStyle(element);
+        return {
+          backgroundColor: style.backgroundColor,
+          borderTopWidth: style.borderTopWidth,
+          borderRightWidth: style.borderRightWidth,
+          borderBottomWidth: style.borderBottomWidth,
+          borderLeftWidth: style.borderLeftWidth,
+        };
+      }),
+    );
+  expect(childSurfaces).toEqual([
+    {
+      backgroundColor: "rgba(0, 0, 0, 0)",
+      borderTopWidth: "0px",
+      borderRightWidth: "0px",
+      borderBottomWidth: "0px",
+      borderLeftWidth: "0px",
+    },
+    {
+      backgroundColor: "rgba(0, 0, 0, 0)",
+      borderTopWidth: "0px",
+      borderRightWidth: "0px",
+      borderBottomWidth: "0px",
+      borderLeftWidth: "0px",
+    },
+  ]);
+});

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -8858,65 +8858,108 @@ kbd {
   color: var(--text-secondary);
 }
 
-/* System Prompt View */
-.system-prompt-view {
-  background: var(--gray-100);
-  border-radius: 0.5rem;
-  margin: 0.5rem 0;
+/* Model and prompt metadata share one line; expanded details span the card below it. */
+.generation-context {
+  display: grid;
+  grid-template-columns: fit-content(45%) minmax(12rem, 1fr);
   width: 100%;
-  border: 1px dashed var(--border);
+  margin: 0.5rem 0;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--bg-tertiary) 70%, var(--bg-base));
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgba(17, 24, 39, 0.04);
 }
 
-.dark .system-prompt-view {
-  background: var(--gray-800);
+.dark .generation-context {
+  background: color-mix(in srgb, var(--bg-tertiary) 38%, var(--bg-base));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+/* System Prompt View */
+.system-prompt-view {
+  display: contents;
 }
 
 .system-prompt-header {
+  grid-column: 2;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-width: 0;
+  min-height: 3.5rem;
   padding: 0.75rem 1rem;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   user-select: none;
 }
 
 .system-prompt-header:hover {
-  background: rgba(0, 0, 0, 0.02);
-  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
 }
 
-.dark .system-prompt-header:hover {
-  background: rgba(255, 255, 255, 0.02);
+.system-prompt-header:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
 }
 
 .system-prompt-summary {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
   flex: 1;
   min-width: 0;
+  white-space: nowrap;
 }
 
 .system-prompt-icon {
-  font-size: 1rem;
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
   flex-shrink: 0;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--text-secondary) 9%, transparent);
+  font-size: 1rem;
+}
+
+.system-prompt-copy {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .system-prompt-label {
+  flex-shrink: 0;
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 0.875rem;
-  color: var(--text-primary);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .system-prompt-meta {
-  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-secondary);
-  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .system-prompt-content {
-  padding: 0 1rem 1rem 1rem;
+  grid-column: 1 / -1;
+  padding: 1rem;
+  border-top: 1px solid var(--border);
 }
 
 .system-prompt-text {
@@ -9474,115 +9517,181 @@ kbd {
   color: var(--text-secondary);
 }
 
-.system-prompt-tools {
-  margin-bottom: 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 0.375rem;
-  overflow: hidden;
+.system-prompt-section {
+  margin-bottom: 0.9rem;
 }
 
-.system-prompt-tools-label {
+.system-prompt-section-label {
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 0.875rem;
-  color: var(--text-primary);
-  font-weight: 500;
-  padding: 0.5rem 0.75rem 0.25rem;
+  font-weight: 600;
 }
 
-.system-prompt-tools-list {
-  padding: 0.25rem 0.75rem 0.5rem;
+.system-prompt-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(15rem, 100%), 1fr));
+  gap: 0.5rem;
 }
 
-.system-prompt-tool-item {
-  border-top: 1px solid var(--border);
-  padding: 0;
+.system-prompt-card {
+  min-width: 0;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--bg-base) 64%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
 }
 
-.system-prompt-tool-item:first-child {
-  border-top: none;
+.system-prompt-card:hover {
+  border-color: color-mix(in srgb, var(--text-secondary) 45%, var(--border));
 }
 
-.system-prompt-tool-header {
+.system-prompt-card--expanded {
+  grid-column: 1 / -1;
+  background: color-mix(in srgb, var(--bg-base) 82%, transparent);
+}
+
+.system-prompt-card-summary {
   display: flex;
-  align-items: baseline;
-  gap: 0.375rem;
-  padding: 0.3rem 0;
+  align-items: flex-start;
+  gap: 0.5rem;
+  width: 100%;
+  min-width: 0;
+  padding: 0.65rem 0.75rem;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
-.system-prompt-tool-header--clickable {
-  cursor: pointer;
-  user-select: none;
+.system-prompt-card-summary:hover {
+  background: color-mix(in srgb, var(--bg-hover) 62%, transparent);
+}
+
+.system-prompt-card-summary:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+.system-prompt-card-copy {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.2rem;
   min-width: 0;
 }
 
-.system-prompt-tool-header--clickable:focus-visible {
-  outline: 2px solid var(--text-accent);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-.system-prompt-tool-header--clickable:hover .system-prompt-tool-name {
-  color: var(--text-accent);
-  text-decoration: underline;
-}
-
-.tool-item-chevron {
-  flex-shrink: 0;
-  color: var(--text-muted, var(--text-secondary));
-  transition: transform 0.15s ease;
-  align-self: center;
-}
-
-.tool-item-chevron--expanded {
-  transform: rotate(90deg);
-}
-
-.tool-item-chevron-spacer {
-  display: inline-block;
-  width: 10px;
-  flex-shrink: 0;
-}
-
-.system-prompt-tool-name {
+.system-prompt-card-name {
+  overflow: hidden;
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 0.75rem;
-  color: var(--text-accent);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.system-prompt-tool-desc {
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  line-height: 1.4;
-  overflow: hidden;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.system-prompt-tool-detail {
-  padding: 0.375rem 0 0.5rem 1.375rem;
+.system-prompt-tool-name {
+  color: var(--text-accent);
 }
 
-.system-prompt-tool-full-desc {
-  font-size: 0.75rem;
+.system-prompt-card-preview {
+  display: -webkit-box;
+  overflow: hidden;
   color: var(--text-secondary);
-  line-height: 1.5;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.system-prompt-card-summary > .tool-chevron {
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+  color: var(--text-muted, var(--text-secondary));
+}
+
+.system-prompt-card-detail {
+  padding: 0.75rem;
+  background: color-mix(in srgb, var(--bg-tertiary) 45%, transparent);
+  border-top: 1px solid var(--border);
+}
+
+.system-prompt-card-full-description {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.55;
   white-space: pre-wrap;
-  margin: 0 0 0.5rem;
+}
+
+.system-prompt-card-metadata {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+}
+
+.system-prompt-card-meta-row {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, max-content) minmax(0, 1fr);
+  gap: 0.75rem;
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.system-prompt-card-meta-row dt {
+  color: var(--text-secondary);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.system-prompt-card-meta-row dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-width: 0;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.system-prompt-card-meta-row code {
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: inherit;
+}
+
+.system-prompt-origin-badge {
+  align-self: flex-start;
+  padding: 0.05rem 0.35rem;
+  background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-secondary) 18%, transparent);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 0.62rem;
+  white-space: nowrap;
 }
 
 .system-prompt-tool-params {
-  margin-top: 0.25rem;
+  margin-top: 0.75rem;
+  overflow-x: auto;
 }
 
 .system-prompt-tool-params-label {
+  margin-bottom: 0.25rem;
+  color: var(--text-secondary);
   font-size: 0.7rem;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-secondary);
-  margin-bottom: 0.25rem;
+  text-transform: uppercase;
 }
 
 .system-prompt-tool-params-table {
@@ -9592,7 +9701,7 @@ kbd {
 }
 
 .system-prompt-tool-param-row td {
-  padding: 0.2rem 0.5rem 0.2rem 0;
+  padding: 0.3rem 0.5rem 0.3rem 0;
   vertical-align: top;
   border-bottom: 1px solid var(--border);
 }
@@ -9602,9 +9711,9 @@ kbd {
 }
 
 .system-prompt-tool-param-name {
-  white-space: nowrap;
-  font-family: var(--font-mono);
   color: var(--text-primary);
+  font-family: var(--font-mono);
+  white-space: nowrap;
 }
 
 .system-prompt-tool-param-name code {
@@ -9613,20 +9722,20 @@ kbd {
 }
 
 .system-prompt-tool-param-required {
-  color: var(--text-accent);
   margin-left: 0.15rem;
+  color: var(--text-accent);
   font-weight: 700;
 }
 
 .system-prompt-tool-param-row td.system-prompt-tool-param-type {
-  white-space: nowrap;
   padding-right: 0.75rem;
+  white-space: nowrap;
 }
 
 .system-prompt-tool-param-type code {
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 0.7rem;
-  color: var(--text-secondary);
 }
 
 .system-prompt-tool-param-desc {
@@ -9640,9 +9749,9 @@ kbd {
 }
 
 .system-prompt-tool-param-enum code {
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 0.7rem;
-  color: var(--text-primary);
 }
 
 .conversation-loading-overlay {
@@ -11176,40 +11285,109 @@ kbd {
 }
 
 .model-bar {
-  background: var(--gray-100);
-  border-radius: 0.5rem;
-  margin: 0.5rem 0 0.25rem 0;
-  width: 100%;
-  border: 1px solid var(--border);
-}
-
-.dark .model-bar {
-  background: var(--gray-800);
+  grid-column: 1;
+  grid-row: 1;
+  max-width: 45vw;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
 }
 
 .model-bar-summary {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.35rem;
+  min-width: 0;
+  min-height: 3.5rem;
   padding: 0.75rem 1rem;
+  overflow: hidden;
+  white-space: nowrap;
   user-select: none;
 }
 
 .model-bar-icon {
-  font-size: 1rem;
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.25rem;
   flex-shrink: 0;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  font-size: 1rem;
 }
 
 .model-bar-label {
+  flex-shrink: 0;
   color: var(--text-primary);
-  font-size: 0.875rem;
-  font-weight: 500;
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 .model-bar-name {
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-secondary);
-  font-size: 0.875rem;
   font-family: var(--font-mono);
+  font-size: 0.875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-bar-comma,
+.model-bar-reasoning {
+  flex-shrink: 0;
+}
+
+@media (max-width: 700px) {
+  .generation-context {
+    grid-template-columns: minmax(0, 42%) minmax(0, 58%);
+  }
+
+  .model-bar-summary,
+  .system-prompt-header {
+    gap: 0.25rem;
+    padding: 0.65rem 0.6rem;
+  }
+
+  .model-bar-label,
+  .system-prompt-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .model-bar-icon,
+  .system-prompt-icon {
+    display: grid;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 0.1rem;
+    font-size: 0.8rem;
+  }
+
+  .model-bar-name,
+  .system-prompt-meta {
+    font-size: 0.7rem;
+  }
+
+  .model-bar-label,
+  .system-prompt-label {
+    font-size: 0.7rem;
+  }
+
+  .system-prompt-copy {
+    gap: 0.25rem;
+  }
 }
 
 /* Floating toolbar shown above/below a text selection inside a commentable

--- a/ui/src/vue/components/ChatInterface.vue
+++ b/ui/src/vue/components/ChatInterface.vue
@@ -155,18 +155,24 @@
               >
             </div>
             <div :class="block.sectionClass">
-              <ModelBar
-                :key="block.modelBar.key"
-                :model="block.modelBar.model"
-                :models-used="block.modelBar.modelsUsed"
-                :models="models"
-                :thinking-level="conversationThinkingLevel"
-              />
-              <SystemPromptView
-                v-for="sp in block.systemPrompts"
-                :key="sp.key"
-                :message="sp.message"
-              />
+              <div
+                v-if="block.modelBar.model || block.systemPrompts.length > 0"
+                class="generation-context"
+                data-testid="generation-context"
+              >
+                <ModelBar
+                  :key="block.modelBar.key"
+                  :model="block.modelBar.model"
+                  :models-used="block.modelBar.modelsUsed"
+                  :models="models"
+                  :thinking-level="conversationThinkingLevel"
+                />
+                <SystemPromptView
+                  v-for="sp in block.systemPrompts"
+                  :key="sp.key"
+                  :message="sp.message"
+                />
+              </div>
               <ChunkHost
                 v-for="chunk in block.chunks"
                 :key="chunk.key"

--- a/ui/src/vue/components/ModelBar.vue
+++ b/ui/src/vue/components/ModelBar.vue
@@ -1,13 +1,12 @@
-<!-- Vue port of components/ModelBar.tsx. Preserves the model-bar / -summary /
-     -icon / -label / -name class contract and the "Reasoning effort" title. -->
+<!-- Compact one-line generation metadata rendered inside the shared context card. -->
 <template>
   <div v-if="model" class="model-bar">
     <div class="model-bar-summary">
-      <span class="model-bar-icon">🤖</span>
-      <span class="model-bar-label">Model</span>
+      <span class="model-bar-icon" aria-hidden="true">🤖</span>
+      <span class="model-bar-label">Model:</span>
       <span class="model-bar-name" :title="modelTitle">{{ displayName }}</span>
-      <span class="model-bar-label" title="Reasoning effort">Reasoning</span>
-      <span class="model-bar-name">{{ effectiveReasoning }}</span>
+      <span class="model-bar-comma" aria-hidden="true">,</span>
+      <span class="model-bar-name model-bar-reasoning">{{ effectiveReasoning }}</span>
     </div>
   </div>
 </template>
@@ -40,8 +39,7 @@ const labels = computed(() => prettyModelLabels(props.models));
 function resolveDisplayName(want: string | null | undefined): string | null | undefined {
   if (!want) return want;
   const obj =
-    props.models.find((m) => m.id === want) ||
-    props.models.find((m) => norm(m.id) === norm(want));
+    props.models.find((m) => m.id === want) || props.models.find((m) => norm(m.id) === norm(want));
   if (!obj) return want;
   return labels.value.get(obj.id) || want;
 }
@@ -50,8 +48,7 @@ const modelObj = computed(() => {
   const want = props.model;
   if (!want) return undefined;
   return (
-    props.models.find((m) => m.id === want) ||
-    props.models.find((m) => norm(m.id) === norm(want))
+    props.models.find((m) => m.id === want) || props.models.find((m) => norm(m.id) === norm(want))
   );
 });
 
@@ -59,11 +56,11 @@ const modelObj = computed(() => {
 // switch) shows "Mixed"; the full list is on hover. Otherwise show the single
 // model's display name.
 const isMixed = computed(() => props.modelsUsed.length > 1);
-const displayName = computed(() =>
-  isMixed.value ? "Mixed" : resolveDisplayName(props.model),
-);
+const displayName = computed(() => (isMixed.value ? "Mixed" : resolveDisplayName(props.model)));
 const modelTitle = computed(() =>
-  isMixed.value ? props.modelsUsed.map((m) => resolveDisplayName(m)).join(" \u2192 ") : undefined,
+  isMixed.value
+    ? props.modelsUsed.map((m) => resolveDisplayName(m)).join(" \u2192 ")
+    : (resolveDisplayName(props.model) ?? undefined),
 );
 
 // The reasoning badge is always shown so a conversation never hides how much

--- a/ui/src/vue/components/SystemPromptView.vue
+++ b/ui/src/vue/components/SystemPromptView.vue
@@ -1,68 +1,158 @@
-<!-- Vue port of components/SystemPromptView.tsx. Collapsible system-prompt card
-     with a tools list. Preserves the system-prompt-* / tool-toggle /
-     tool-chevron / tool-item-chevron class contract and the Collapse/Expand
-     aria-labels. The React ToolItem subcomponent is inlined with a per-tool
-     expanded-state map keyed by tool name. -->
+<!-- Collapsible model-context metadata with expandable skill and tool cards. -->
 <template>
   <div v-if="systemPromptText" class="system-prompt-view">
-    <div class="system-prompt-header" @click="isExpanded = !isExpanded">
-      <div class="system-prompt-summary">
-        <span class="system-prompt-icon">📋</span>
-        <span class="system-prompt-label">System Prompt</span>
-        <span class="system-prompt-meta">
-          {{ lineCount }} lines, {{ sizeKb }} KB{{
-            tools.length > 0 ? ` · ${tools.length} tools` : ""
-          }}
+    <button
+      type="button"
+      class="system-prompt-header"
+      :aria-expanded="isExpanded"
+      @click="isExpanded = !isExpanded"
+    >
+      <span class="system-prompt-summary">
+        <span class="system-prompt-icon" aria-hidden="true">📋</span>
+        <span class="system-prompt-copy">
+          <span class="system-prompt-label">System Prompt:</span>
+          <span class="system-prompt-meta">
+            <span>{{ countLabel(tools.length, "tool") }}</span>
+            <span aria-hidden="true">,</span>
+            <span>{{ countLabel(skills.length, "skill") }}</span>
+          </span>
         </span>
-      </div>
-      <button
-        class="tool-toggle"
-        :aria-label="isExpanded ? 'Collapse' : 'Expand'"
-        :aria-expanded="isExpanded"
-      >
+      </span>
+      <span class="sr-only">{{ isExpanded ? "Collapse" : "Expand" }}</span>
+      <span class="tool-toggle" aria-hidden="true">
         <ToolChevron :expanded="isExpanded" />
-      </button>
-    </div>
+      </span>
+    </button>
 
     <div v-if="isExpanded" class="system-prompt-content">
-      <div v-if="tools.length > 0" class="system-prompt-tools">
-        <div class="system-prompt-tools-label">🔧 Tools ({{ tools.length }})</div>
-        <div class="system-prompt-tools-list">
-          <div v-for="tool in tools" :key="tool.name" class="system-prompt-tool-item">
-            <div
-              :class="`system-prompt-tool-header${hasDetails(tool) ? ' system-prompt-tool-header--clickable' : ''}`"
-              :tabindex="hasDetails(tool) ? 0 : undefined"
-              :role="hasDetails(tool) ? 'button' : undefined"
-              :aria-expanded="hasDetails(tool) ? !!expanded[tool.name] : undefined"
-              @click="hasDetails(tool) && toggle(tool.name)"
-              @keydown="onHeaderKeydown($event, tool)"
+      <section v-if="skills.length > 0" class="system-prompt-section system-prompt-skills">
+        <h3 class="system-prompt-section-label">✨ Skills ({{ skills.length }})</h3>
+        <div class="system-prompt-card-grid">
+          <article
+            v-for="skill in skills"
+            :key="skill.name"
+            class="system-prompt-card system-prompt-skill-item"
+            :class="{
+              'system-prompt-card--expanded': isCardExpanded('skill', skill.name),
+            }"
+          >
+            <button
+              type="button"
+              class="system-prompt-card-summary"
+              :aria-expanded="isCardExpanded('skill', skill.name)"
+              @click="toggleCard('skill', skill.name)"
             >
-              <svg
-                v-if="hasDetails(tool)"
-                width="10"
-                height="10"
-                viewBox="0 0 10 10"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                :class="`tool-item-chevron${expanded[tool.name] ? ' tool-item-chevron--expanded' : ''}`"
-              >
-                <path
-                  d="M3 2L7 5L3 8"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-              <span v-else class="tool-item-chevron-spacer" />
-              <code class="system-prompt-tool-name">{{ tool.name }}</code>
-              <span class="system-prompt-tool-desc">{{ firstLine(tool) }}</span>
-            </div>
+              <span class="system-prompt-card-copy">
+                <code class="system-prompt-card-name">{{ skill.name }}</code>
+                <span class="system-prompt-card-preview">{{ skill.description }}</span>
+              </span>
+              <ToolChevron :expanded="isCardExpanded('skill', skill.name)" />
+              <span class="sr-only">
+                {{ isCardExpanded("skill", skill.name) ? "Collapse" : "Expand" }}
+              </span>
+            </button>
 
-            <div v-if="expanded[tool.name] && hasDetails(tool)" class="system-prompt-tool-detail">
-              <p v-if="tool.description.trim().includes('\n')" class="system-prompt-tool-full-desc">
-                {{ tool.description.trim().split("\n").slice(1).join("\n").trim() }}
+            <div v-if="isCardExpanded('skill', skill.name)" class="system-prompt-card-detail">
+              <p class="system-prompt-card-full-description">{{ skill.description }}</p>
+              <dl class="system-prompt-card-metadata">
+                <div v-if="skill.source_path || skill.origin" class="system-prompt-card-meta-row">
+                  <dt>Source</dt>
+                  <dd>
+                    <code v-if="skill.source_path">{{ skill.source_path }}</code>
+                    <span v-if="skill.origin" class="system-prompt-origin-badge">
+                      {{ skill.origin }}
+                    </span>
+                  </dd>
+                </div>
+                <div v-if="skill.activate" class="system-prompt-card-meta-row">
+                  <dt>Activate</dt>
+                  <dd>
+                    <code>{{ skill.activate }}</code>
+                  </dd>
+                </div>
+                <div v-if="skill.compatibility" class="system-prompt-card-meta-row">
+                  <dt>Compatibility</dt>
+                  <dd>{{ skill.compatibility }}</dd>
+                </div>
+                <div v-if="skill.allowed_tools" class="system-prompt-card-meta-row">
+                  <dt>Allowed tools</dt>
+                  <dd>
+                    <code>{{ skill.allowed_tools }}</code>
+                  </dd>
+                </div>
+                <div v-if="skill.when" class="system-prompt-card-meta-row">
+                  <dt>When</dt>
+                  <dd>{{ skill.when }}</dd>
+                </div>
+                <div v-if="skill.license" class="system-prompt-card-meta-row">
+                  <dt>License</dt>
+                  <dd>{{ skill.license }}</dd>
+                </div>
+                <div
+                  v-for="[key, value] in metadataEntries(skill)"
+                  :key="key"
+                  class="system-prompt-card-meta-row"
+                >
+                  <dt>{{ key }}</dt>
+                  <dd>{{ value }}</dd>
+                </div>
+              </dl>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section v-if="tools.length > 0" class="system-prompt-section system-prompt-tools">
+        <h3 class="system-prompt-section-label">🔧 Tools ({{ tools.length }})</h3>
+        <div class="system-prompt-card-grid">
+          <article
+            v-for="tool in tools"
+            :key="tool.name"
+            class="system-prompt-card system-prompt-tool-item"
+            :class="{
+              'system-prompt-card--expanded': isCardExpanded('tool', tool.name),
+            }"
+          >
+            <button
+              type="button"
+              class="system-prompt-card-summary"
+              :aria-expanded="isCardExpanded('tool', tool.name)"
+              @click="toggleCard('tool', tool.name)"
+            >
+              <span class="system-prompt-card-copy">
+                <code class="system-prompt-card-name system-prompt-tool-name">
+                  {{ tool.name }}
+                </code>
+                <span class="system-prompt-card-preview">{{ toolPreview(tool) }}</span>
+              </span>
+              <ToolChevron :expanded="isCardExpanded('tool', tool.name)" />
+              <span class="sr-only">
+                {{ isCardExpanded("tool", tool.name) ? "Collapse" : "Expand" }}
+              </span>
+            </button>
+
+            <div v-if="isCardExpanded('tool', tool.name)" class="system-prompt-card-detail">
+              <p v-if="tool.description.trim()" class="system-prompt-card-full-description">
+                {{ tool.description.trim() }}
               </p>
+              <dl class="system-prompt-card-metadata">
+                <div v-if="tool.source_path || tool.origin" class="system-prompt-card-meta-row">
+                  <dt>Source</dt>
+                  <dd>
+                    <code v-if="tool.source_path">{{ tool.source_path }}</code>
+                    <span v-if="tool.origin" class="system-prompt-origin-badge">
+                      {{ tool.origin }}
+                    </span>
+                  </dd>
+                </div>
+                <div v-if="tool.type" class="system-prompt-card-meta-row">
+                  <dt>Type</dt>
+                  <dd>
+                    <code>{{ tool.type }}</code>
+                  </dd>
+                </div>
+              </dl>
+
               <div v-if="Object.keys(propsOf(tool)).length > 0" class="system-prompt-tool-params">
                 <div class="system-prompt-tool-params-label">Parameters</div>
                 <table class="system-prompt-tool-params-table">
@@ -90,9 +180,9 @@
                           class="system-prompt-tool-param-enum"
                         >
                           {{ " " }}Allowed values:{{ " " }}
-                          <template v-for="(v, i) in prop.enum" :key="i">
-                            <template v-if="i > 0">, </template>
-                            <code>{{ String(v) }}</code>
+                          <template v-for="(value, index) in prop.enum" :key="index">
+                            <template v-if="index > 0">, </template>
+                            <code>{{ String(value) }}</code>
                           </template>
                         </span>
                       </td>
@@ -101,9 +191,10 @@
                 </table>
               </div>
             </div>
-          </div>
+          </article>
         </div>
-      </div>
+      </section>
+
       <pre class="system-prompt-text">{{ systemPromptText }}</pre>
     </div>
   </div>
@@ -112,6 +203,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from "vue";
 import type { Message, LLMContent } from "../../types";
+import { extractSystemPromptSkills, type SystemPromptSkill } from "./systemPromptSkills";
 import ToolChevron from "./tools/ToolChevron.vue";
 
 interface JSONSchemaProperty {
@@ -134,46 +226,57 @@ interface ToolDescription {
   name: string;
   description: string;
   parameters?: JSONSchema;
+  source_path?: string;
+  origin?: string;
+  type?: string;
+  server_side?: boolean;
 }
 
 interface SystemPromptDisplayData {
   tools?: ToolDescription[];
+  skills?: SystemPromptSkill[];
 }
 
 const props = defineProps<{ message: Message }>();
 
 const isExpanded = ref(false);
-const expanded = reactive<Record<string, boolean>>({});
+const expandedCards = reactive<Record<string, boolean>>({});
 
-function toggle(name: string) {
-  expanded[name] = !expanded[name];
+function countLabel(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
-function firstLine(tool: ToolDescription): string {
-  return tool.description.trim().split("\n")[0];
+function cardKey(kind: "skill" | "tool", name: string): string {
+  return `${kind}:${name}`;
 }
-function hasDetails(tool: ToolDescription): boolean {
-  return (
-    tool.description.trim().includes("\n") ||
-    Boolean(tool.parameters?.properties && Object.keys(tool.parameters.properties).length > 0)
-  );
+
+function isCardExpanded(kind: "skill" | "tool", name: string): boolean {
+  return Boolean(expandedCards[cardKey(kind, name)]);
 }
+
+function toggleCard(kind: "skill" | "tool", name: string): void {
+  const key = cardKey(kind, name);
+  expandedCards[key] = !expandedCards[key];
+}
+
+function toolPreview(tool: ToolDescription): string {
+  return tool.description.trim().split("\n")[0] || "Provider-managed tool.";
+}
+
 function requiredOf(tool: ToolDescription): Set<string> {
   return new Set(tool.parameters?.required ?? []);
 }
+
 function propsOf(tool: ToolDescription): Record<string, JSONSchemaProperty> {
   return tool.parameters?.properties ?? {};
 }
+
 function typeLabel(prop: JSONSchemaProperty): string {
   return Array.isArray(prop.type) ? prop.type.join(" | ") : (prop.type ?? "");
 }
 
-function onHeaderKeydown(e: KeyboardEvent, tool: ToolDescription) {
-  if (!hasDetails(tool)) return;
-  if (e.key === "Enter" || e.key === " ") {
-    e.preventDefault();
-    toggle(tool.name);
-  }
+function metadataEntries(skill: SystemPromptSkill): [string, string][] {
+  return Object.entries(skill.metadata ?? {});
 }
 
 const systemPromptText = computed<string>(() => {
@@ -184,7 +287,9 @@ const systemPromptText = computed<string>(() => {
         ? JSON.parse(props.message.llm_data)
         : props.message.llm_data;
     if (llmData && llmData.Content && Array.isArray(llmData.Content)) {
-      const textContent = llmData.Content.find((c: LLMContent) => c.Type === 2 && c.Text);
+      const textContent = llmData.Content.find(
+        (content: LLMContent) => content.Type === 2 && content.Text,
+      );
       if (textContent) return textContent.Text;
     }
   } catch (err) {
@@ -193,20 +298,20 @@ const systemPromptText = computed<string>(() => {
   return "";
 });
 
-const tools = computed<ToolDescription[]>(() => {
-  if (!props.message.display_data) return [];
+const displayData = computed<SystemPromptDisplayData>(() => {
+  if (!props.message.display_data) return {};
   try {
-    const displayData: SystemPromptDisplayData =
-      typeof props.message.display_data === "string"
-        ? JSON.parse(props.message.display_data)
-        : (props.message.display_data as SystemPromptDisplayData);
-    if (displayData && displayData.tools) return displayData.tools;
+    return typeof props.message.display_data === "string"
+      ? JSON.parse(props.message.display_data)
+      : (props.message.display_data as SystemPromptDisplayData);
   } catch (err) {
     console.error("Failed to parse system prompt display data:", err);
+    return {};
   }
-  return [];
 });
 
-const lineCount = computed(() => systemPromptText.value.split("\n").length);
-const sizeKb = computed(() => (systemPromptText.value.length / 1024).toFixed(1));
+const skills = computed(() =>
+  extractSystemPromptSkills(systemPromptText.value, displayData.value.skills ?? []),
+);
+const tools = computed(() => displayData.value.tools ?? []);
 </script>

--- a/ui/src/vue/components/systemPromptSkills.test.ts
+++ b/ui/src/vue/components/systemPromptSkills.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { extractSystemPromptSkills } from "./systemPromptSkills";
+
+const prompt = `Before
+<available_skills>
+<skill>
+<name>diagrams</name>
+<description>Draw &#34;quoted&#34; &amp; explain &lt;things&gt;.</description>
+<activate>shelley skill cat diagrams</activate>
+</skill>
+<skill>
+<name>deploy</name>
+<description>Ship it.</description>
+<activate>shelley skill cat deploy</activate>
+</skill>
+</available_skills>
+After`;
+
+assert.deepEqual(extractSystemPromptSkills(prompt), [
+  {
+    name: "diagrams",
+    description: 'Draw "quoted" & explain <things>.',
+    activate: "shelley skill cat diagrams",
+  },
+  {
+    name: "deploy",
+    description: "Ship it.",
+    activate: "shelley skill cat deploy",
+  },
+]);
+assert.deepEqual(
+  extractSystemPromptSkills(prompt, [
+    {
+      name: "diagrams",
+      description: "Original metadata description",
+      activate: "original activation",
+      source_path: "/tmp/diagrams/SKILL.md",
+      origin: "File",
+      compatibility: "Requires SVG support",
+    },
+  ]),
+  [
+    {
+      name: "diagrams",
+      description: 'Draw "quoted" & explain <things>.',
+      activate: "shelley skill cat diagrams",
+      source_path: "/tmp/diagrams/SKILL.md",
+      origin: "File",
+      compatibility: "Requires SVG support",
+    },
+    {
+      name: "deploy",
+      description: "Ship it.",
+      activate: "shelley skill cat deploy",
+    },
+  ],
+);
+assert.deepEqual(extractSystemPromptSkills("No skills here"), []);
+
+console.log("systemPromptSkills: 3 passed");

--- a/ui/src/vue/components/systemPromptSkills.ts
+++ b/ui/src/vue/components/systemPromptSkills.ts
@@ -1,0 +1,53 @@
+export interface SystemPromptSkill {
+  name: string;
+  description: string;
+  activate: string;
+  source_path?: string;
+  origin?: string;
+  license?: string;
+  compatibility?: string;
+  when?: string;
+  allowed_tools?: string;
+  metadata?: Record<string, string>;
+}
+
+function decodeCodePoint(entity: string, value: string, radix: number): string {
+  const codePoint = Number.parseInt(value, radix);
+  return Number.isFinite(codePoint) && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : entity;
+}
+
+function decodeXML(value: string): string {
+  return value
+    .replace(/&#x([0-9a-f]+);/gi, (entity, codePoint) => decodeCodePoint(entity, codePoint, 16))
+    .replace(/&#(\d+);/g, (entity, codePoint) => decodeCodePoint(entity, codePoint, 10))
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function tagValue(block: string, tag: string): string {
+  const match = block.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+  return decodeXML(match?.[1]?.trim() ?? "");
+}
+
+export function extractSystemPromptSkills(
+  prompt: string,
+  metadata: SystemPromptSkill[] = [],
+): SystemPromptSkill[] {
+  const section = prompt.match(/<available_skills>([\s\S]*?)<\/available_skills>/)?.[1];
+  if (!section) return [];
+
+  const metadataByName = new Map(metadata.map((skill) => [skill.name, skill]));
+  return Array.from(section.matchAll(/<skill>([\s\S]*?)<\/skill>/g), (match) => {
+    const parsed = {
+      name: tagValue(match[1], "name"),
+      description: tagValue(match[1], "description"),
+      activate: tagValue(match[1], "activate"),
+    };
+    return { ...metadataByName.get(parsed.name), ...parsed };
+  }).filter((skill) => skill.name);
+}


### PR DESCRIPTION
## Summary
- combine model and system-prompt metadata into one line
- render skills and tools as expandable cards
- show source and parameter metadata; remove the vertical divider

## Tests
- pnpm type-check / type-check:vue / lint / test
- go test ./claudetool ./server
- Playwright generation-context spec